### PR TITLE
Enable to setting context path with 'hpi.prefix' property.

### DIFF
--- a/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AbstractJettyMojo.java
@@ -60,7 +60,7 @@ public abstract class AbstractJettyMojo extends AbstractMojo {
     /**
      * The context path for the webapp. Defaults to "/"
      *
-     * @parameter expression="/"
+     * @parameter expression="${hpi.prefix}" default-value="/"
      * @required
      */
     private String contextPath;


### PR DESCRIPTION
I enabled to setting context path with 'hpi.prefix' property. (JENKINS-1350)

Usage:
- contextPath = "/"

mvn hpi:run
- contextPath = "/jenkins"

mvn hpi:run -Dhpi.prefix=/jenkins
