### PR TITLE
make the hpi plugin work again.

### DIFF
--- a/src/main/resources/META-INF/archetype.xml
+++ b/src/main/resources/META-INF/archetype.xml
@@ -9,6 +9,5 @@
   <resources>
     <resource>pom.xml</resource>
     <resource>src/main/resources/index.jelly</resource>
-    <resource>src/main/webapp/help-globalConfig.html</resource>
   </resources>
 </archetype>


### PR DESCRIPTION
This change updates the archetype so that the project can be genereated successfully.

I'm not sure of the removal of the actual file (see commit 3132dd9404) - it may be that these files would be usefull to have and should be re-added but I assume that Kohsuke knew what he was doing :-)
