### PR TITLE
Switch role-hint for jenkins-module to jm.

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -43,7 +43,7 @@
     <!-- Jenkins module -->
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
-      <role-hint>jenkins-module</role-hint>
+      <role-hint>jm</role-hint>
       <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
       <configuration>
         <lifecycles>
@@ -70,7 +70,7 @@
     </component>
     <component>
       <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>jenkins-module</role-hint>
+      <role-hint>jm</role-hint>
       <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
       <configuration>
         <extension>jm</extension>


### PR DESCRIPTION
This way, we can use <packaging>jm</packaging>, so that the packaging
in the POM matches the actual artifact file extension. This will get
us around a problem where Gradle looks at the POM's "packaging" field
to determine the file extension for an artifact. This means that if
you end up with a dependency on something with packaging
"jenkins-module", it expects to find a file ending with
".jenkins-module" and fails otherwise. So we really want the role-hint
(which is what you specify in <packaging>) to match the file
extension, I think.

That said, I'll also ask Hans Dockter if he has any thoughts. =)
