### PR TITLE
Add java7 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,14 @@
   <version>1.85-SNAPSHOT</version>
   <description>Maven2 plugin for developing Jenkins plugins</description>
 
+  <contributors>
+    <contributor>
+      <name>Marvin Froeder</name>
+      <email>marvin at marvinformatics.com</email>
+      <url>http://about.me/velo</url>
+    </contributor>
+  </contributors>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -46,7 +54,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>(1.6,1.7)</version>
+                  <version>(1.6,1.8)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -213,6 +221,21 @@
   </repositories>
 
   <profiles>
+    <profile>
+      <id>java7</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>${java.version}</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>run-its</id>
       <build>


### PR DESCRIPTION
Made maven-hpi-plugin compatible with java 7.

Tried it here and it is working just fine, it just gives me a huge alert, but works!

```
warning: The apt tool and its associated API are planned to be
removed in the next major JDK release.  These features have been
superseded by javac and the standardized annotation processing API,
javax.annotation.processing and javax.lang.model.  Users are
recommended to migrate to the annotation processing features of
javac; see the javac man page for more information.
```
