### PR TITLE
Fix malformed components.xml file

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -121,4 +121,5 @@
         <addedToClasspath>true</addedToClasspath>
       </configuration>
     </component>
+  </components>
 </component-set>


### PR DESCRIPTION
The file is malformed xml: a closing components tag is missing.
