### PR TITLE
[FIXED JENKINS-20337] plugin loses its global configuration on Jenkins restart

### DIFF
--- a/hpi-archetype/src/main/java/HelloWorldBuilder.java
+++ b/hpi-archetype/src/main/java/HelloWorldBuilder.java
@@ -89,6 +89,14 @@ public class HelloWorldBuilder extends Builder {
         private boolean useFrench;
 
         /**
+         * In order to load the persisted global configuration, you have to 
+         * call load() in the constructor.
+         */
+        public DescriptorImpl() {
+            load();
+        }
+
+        /**
          * Performs on-the-fly validation of the form field 'name'.
          *
          * @param value


### PR DESCRIPTION
Fixes [JENKINS-20337](https://issues.jenkins-ci.org/browse/JENKINS-20337) by adding a call to load() to the constructor of DescriptorImpl in the archetype.

Presumably restoring persisted configuration worked until https://github.com/jenkinsci/jenkins/commit/b46bf8b2b4dd56fb0fa41c4d98a0a8cadd4ae191, which removed the call to load() in Descriptor's constructor.
