### PR TITLE
Fix webApp parameter

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -252,7 +252,9 @@ public class RunMojo extends AbstractJetty6Mojo {
                 .groupIdIs("org.jenkins-ci.main","org.jvnet.hudson.main")
                 .artifactIdIsNot("remoting");       // remoting moved to its own release cycle
 
-        webApp = getJenkinsWarArtifact().getFile();
+        if (webApp == null) {
+            webApp = getJenkinsWarArtifact().getFile();
+        }
 
         // make sure all the relevant Jenkins artifacts have the same version
         for (Artifact a : jenkinsArtifacts) {


### PR DESCRIPTION
According to [documentation], user should be able to specify location of jenkins.war via webApp parameter. It currently doesn't work, because parameter is ignored. This PR should fix the issue.

[documentation]: https://jenkins-ci.org/maven-hpi-plugin/run-mojo.html