### PR TITLE
Improved comment for Jenkins version in pom.xml

### DIFF
--- a/hpi-archetype/pom.xml
+++ b/hpi-archetype/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.2</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.532.2</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <!-- $ --><groupId>org.jenkins-ci.tools</groupId><!-- /$ -->


### PR DESCRIPTION
Some inexperienced plugin authors seem to think they need to keep this "up to date", e.g. [here](https://github.com/jenkinsci/rpmsign-plugin/commit/b3fb77268f5199e9a0dcfb33b11988b6772f1a10#commitcomment-5913989), not realizing that users must be at least this tall to ride.
