### PR TITLE
[JENKINS-24374] - Added code to skip maven dependencies of type pom that were being added to the Libraries

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
@@ -142,6 +142,10 @@ public class HplMojo extends AbstractHpiMojo {
                     continue OUTER;
             }
 
+            //Skip artifacts of type pom
+            if(artifact.getType().equals("pom"))
+                continue;
+
             ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
             if (!artifact.isOptional() && filter.include(artifact.artifact)) {
                 paths.add(artifact.getFile().getPath());


### PR DESCRIPTION
While working on changes to the [m2release plugin](https://github.com/jenkinsci/m2release-plugin), I found that the .hli file being produced by the maven-hpi-plugin contained paths to .pom files in the Libraries section. This only became an issue when I moved the m2release plugin to the 1.532 version of Jenkins core as the updated ClassPluginStrategy class used the AntClassLoader and no longer the URLClassloader to load dependencies. Attempting to start Jenkins using mvn hpi:run resulted in a java.util.zip.ZipException. 

Adding the following dependency from the m2release plugin to a pom reproduces the issue:

``` <dependency>
          <groupId>org.apache.maven.release</groupId>
          <artifactId>maven-release-manager</artifactId>
          <version>2.1</version>
          <exclusions>
              <exclusion>
                  <artifactId>maven-project</artifactId>
                  <groupId>org.apache.maven</groupId>
              </exclusion>
          </exclusions>
      </dependency>
```

To fix the issue I just skip dependencies of type pom.
