### PR TITLE
Add the ability to bundle optional plugins separately from regular

### DIFF
--- a/src/it/bundle-fails-optional-conflict/invoker.properties
+++ b/src/it/bundle-fails-optional-conflict/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=clean generate-resources
+invoker.buildResult = failure

--- a/src/it/bundle-fails-optional-conflict/pom.xml
+++ b/src/it/bundle-fails-optional-conflict/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bundle-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>parameterized-trigger</artifactId>
+      <version>2.26</version>
+      <type>hpi</type>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.2</version>
+      <type>hpi</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>bundle-plugins</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/bundle-with-optional-deps/invoker.properties
+++ b/src/it/bundle-with-optional-deps/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=clean generate-resources

--- a/src/it/bundle-with-optional-deps/pom.xml
+++ b/src/it/bundle-with-optional-deps/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bundle-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+      <version>1.10</version>
+      <type>hpi</type>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <version>1.6</version>
+      <type>hpi</type>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>support-core</artifactId>
+      <version>2.18</version>
+      <type>hpi</type>
+      <optional>true</optional>
+    </dependency>
+
+  </dependencies>
+  
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>bundle-plugins</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/bundle-with-optional-deps/verify.groovy
+++ b/src/it/bundle-with-optional-deps/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/bundle-it/WEB-INF/plugins/ssh-credentials.hpi').exists();
+assert new File(basedir, 'target/bundle-it/WEB-INF/plugins/credentials.hpi').exists();
+assert new File(basedir, 'target/bundle-it/WEB-INF/optional-plugins/ssh-slaves.hpi').exists();
+assert new File(basedir, 'target/bundle-it/WEB-INF/optional-plugins/support-core.hpi').exists();
+assert new File(basedir, 'target/bundle-it/WEB-INF/optional-plugins/metrics.hpi').exists();
+
+String manifest = new File(basedir, 'target/plugin-manifest.txt').text
+
+assert manifest =~ /ssh-credentials\s+1\.10/ : "direct non-optional dependency on ssh-credentials"
+assert manifest =~ /credentials\s+1\.16\.1/ : "transitive non-optional dependency of ssh-credentials"
+assert manifest =~ /ssh-slaves\s+1\.6/ : "direct optional dependency on ssh-slaves"
+assert ! (manifest =~ /credentials\s+1\.9\.4/) : "don't pull in the transitive dependency from ssh-slaves as already pulled in"
+assert manifest =~ /support-core\s+2\.18/ : "direct optional dependency on support-core"
+assert manifest =~ /metrics\s+3\.0\.0/ : "transitive optional dependency on metrics"
+
+return true;

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
@@ -160,7 +160,7 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
             // so much simpler to force the user to explicitly resolve the conflict by adding an explicit
             // dependency
             
-            Set<String> optionalDepenencyIssue = new LinkedHashSet<String>();
+            Set<String> optionalDependencyIssue = new LinkedHashSet<String>();
             for (MavenArtifact a: selected.values()) {
                 try {
                     final MavenProject pom = a.resolvePom();
@@ -174,7 +174,7 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
                                     "%s: optional dependency of %s version %s conflicts with the bundled version %s",
                                     a.getArtifactId(), d.getArtifactId(), d.getVersion(), matching.getVersion());
                             getLog().error(message);
-                            optionalDepenencyIssue.add(message);
+                            optionalDependencyIssue.add(message);
                         }
                     }
                 } catch (ProjectBuildingException e) {
@@ -182,13 +182,13 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
                             a.getGroupId(), a.getArtifactId(), a.getVersion()), e);
                 }
             }
-            if (!optionalDepenencyIssue.isEmpty()) {
+            if (!optionalDependencyIssue.isEmpty()) {
                 if (ignoreOptionalDepenencyConflicts) {
                     getLog().warn("Ignoring optional dependency conflicts");
                 } else {
                     throw new MojoFailureException(
                             "Optional dependencies are incompatible with bundled dependencies:\n  " + StringUtils
-                                    .join(optionalDepenencyIssue, "\n  "));
+                                    .join(optionalDependencyIssue, "\n  "));
                 }
             }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
@@ -60,6 +60,7 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
 
     /**
      * Where to copy optional plugins into.
+     * @see <a href="https://github.com/jenkinsci/optional-plugin-helper-module">optional-plugin-helper-module</a>
      */
     @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}/WEB-INF/optional-plugins/")
     private File optionalOutputDirectory;
@@ -198,7 +199,7 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
             }
 
             int artifactIdLength = "Artifact ID".length(); // how many chars does it take to print artifactId?
-            int groupIdLength = "Group ID".length(); // how many chars does it take to print artifactId?
+            int groupIdLength = "Group ID".length(); // how many chars does it take to print groupId?
             int versionLength = "Version".length();
             for (MavenArtifact a : selected.values()) {
                 MavenArtifact hpi = a.getHpi();

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
@@ -3,12 +3,13 @@ package org.jenkinsci.maven.plugins.hpi;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.resolver.ArtifactCollector;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -16,7 +17,9 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.shared.artifact.filter.ScopeArtifactFilter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.shared.artifact.filter.collection.AbstractArtifactsFilter;
 import org.apache.maven.shared.artifact.filter.collection.TypeFilter;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -27,12 +30,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
 
 /**
  * Take the current project, list up all the transitive dependencies, then copy them
@@ -56,6 +58,19 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
     @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}/WEB-INF/plugins/")
     private File outputDirectory;
 
+    /**
+     * Where to copy optional plugins into.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}/WEB-INF/optional-plugins/")
+    private File optionalOutputDirectory;
+
+    /**
+     * By default the build will fail if one of the bundled plugins has an optional dependency on a newer version
+     * of another bundled plugin.
+     */
+    @Parameter(property = "hpi.ignoreOptionalDepenencyConflicts")
+    private boolean ignoreOptionalDepenencyConflicts;
+
     @Component
     protected ArtifactResolver resolver;
 
@@ -77,7 +92,9 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
             }
         }
         if (!badDependencies.isEmpty()) {
-            throw new MojoExecutionException("The following plugin dependencies are missing the <type> tag required by the bundle-plugins goal: " + badDependencies );
+            throw new MojoFailureException(
+                    "The following plugin dependencies are missing the <type> tag required by the bundle-plugins " 
+                            + "goal:\n  " + StringUtils.join(badDependencies, "\n  "));
         }
         TypeFilter typeFilter = new TypeFilter("hpi,jpi", null);
         // the HPI packaging type is brain-dead... since nobody lists plugin dependencies with <type>hpi</type>
@@ -85,15 +102,14 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
         // further we need to set <scope>provided</scope> in order to keep this off the classpath as then
         // the war plugin would suck them in anyways
         Set<Artifact> artifacts = typeFilter.filter(project.getDependencyArtifacts());
-        ScopeArtifactFilter scopeFilter = new ScopeArtifactFilter(DefaultArtifact.SCOPE_PROVIDED);
         artifacts = typeFilter.filter(artifacts);
+        Set<Artifacts> nonOptionalArtifacts = new OptionalFilter(false).filter(artifacts);
         try {
             // This would be unnecessary and trivial if the hpi packaging was defined correctly
             ArtifactResolutionResult r = resolver.resolveTransitively(artifacts, project.getArtifact(), remoteRepos, localRepository, artifactMetadataSource);
+            ArtifactResolutionResult noR = resolver.resolveTransitively(nonOptionalArtifacts, project.getArtifact(), remoteRepos, localRepository, artifactMetadataSource);
 
             List<MavenArtifact> hpis = new ArrayList<MavenArtifact>();
-            int artifactIdLength = 0; // how many chars does it take to print artifactId?
-            int versionLength = 0;
 
 
             // resolveTransitively resolves items in the 'all' set individually,
@@ -101,6 +117,8 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
             // we need to select the latest
             Map<String, MavenArtifact> selected = new HashMap<String, MavenArtifact>();
 
+            // first we want to take all the dependencies as a complete set
+            
             for (Artifact o : (Set<Artifact>)r.getArtifacts()) {
                 MavenArtifact a = wrap(o);
                 if (a.isPlugin()) {
@@ -115,17 +133,85 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
                     selected.put(a.getArtifactId(), cur);
                 }
             }
+            
+            // now just take the non-optional ones (these may have a higher minimum versions when we exclude the optional ones)
+            // (due to the ordering effect of dependencies when resolving conflicts in case you were wondering)
+            
+            Set<String> nonOptional = new HashSet<String>();
+            for (Artifact o: (Set<Artifact>)noR.getArtifacts()) {
+                MavenArtifact a = wrap(o);
+                if (a.isPlugin()) {
+                    nonOptional.add(o.getArtifactId());
+                    MavenArtifact cur = selected.get(a.getArtifactId());
+                    if (cur != null) {
+                        if (cur.getVersionNumber().compareTo(a.getVersionNumber()) < 0) {
+                            cur = a;
+                        }
+                    } else {
+                        cur = a;
+                    }
+                    selected.put(a.getArtifactId(), cur);
+                }
+            }
+
+            // now we just need to check if the optional dependencies have issues
+            // in theory we do not need to fail the build if a transitive dependency has issues
+            // we could just up-version it, but that would put us back to the start in terms of dependency resolution
+            // so much simpler to force the user to explicitly resolve the conflict by adding an explicit
+            // dependency
+            
+            Set<String> optionalDepenencyIssue = new LinkedHashSet<String>();
+            for (MavenArtifact a: selected.values()) {
+                try {
+                    final MavenProject pom = a.resolvePom();
+                    for (Dependency d : (List<Dependency>)pom.getDependencies()) {
+                        if (!d.isOptional()) continue;
+                        if (!selected.containsKey(d.getArtifactId())) continue;
+                        MavenArtifact matching = selected.get(d.getArtifactId());
+                        if (!StringUtils.equals(d.getGroupId(), matching.getGroupId())) continue;
+                        if (matching.getVersionNumber().compareTo(new DefaultArtifactVersion(d.getVersion())) < 0) {
+                            final String message = String.format(
+                                    "%s: optional dependency of %s version %s conflicts with the bundled version %s",
+                                    a.getArtifactId(), d.getArtifactId(), d.getVersion(), matching.getVersion());
+                            getLog().error(message);
+                            optionalDepenencyIssue.add(message);
+                        }
+                    }
+                } catch (ProjectBuildingException e) {
+                    getLog().warn(String.format("Could not resolve pom of %s:%s:%s to check optional dependencies",
+                            a.getGroupId(), a.getArtifactId(), a.getVersion()), e);
+                }
+            }
+            if (!optionalDepenencyIssue.isEmpty()) {
+                if (ignoreOptionalDepenencyConflicts) {
+                    getLog().warn("Ignoring optional dependency conflicts");
+                } else {
+                    throw new MojoFailureException(
+                            "Optional dependencies are incompatible with bundled dependencies:\n  " + StringUtils
+                                    .join(optionalDepenencyIssue, "\n  "));
+                }
+            }
 
             outputDirectory.mkdirs();
+            if (!nonOptional.containsAll(selected.keySet())) {
+                optionalOutputDirectory.mkdirs();
+            }
 
+            int artifactIdLength = "Artifact ID".length(); // how many chars does it take to print artifactId?
+            int groupIdLength = "Group ID".length(); // how many chars does it take to print artifactId?
+            int versionLength = "Version".length();
             for (MavenArtifact a : selected.values()) {
                 MavenArtifact hpi = a.getHpi();
                 getLog().debug("Copying " + hpi.getFile());
 
 
-                FileUtils.copyFile(hpi.getFile(), new File(outputDirectory, hpi.getArtifactId() + ".hpi"));
+                FileUtils.copyFile(hpi.getFile(), 
+                        new File(nonOptional.contains(hpi.getArtifactId()) ? outputDirectory : optionalOutputDirectory, 
+                                hpi.getArtifactId() + ".hpi")
+                );
                 hpis.add(hpi);
                 artifactIdLength = Math.max(artifactIdLength, hpi.getArtifactId().length());
+                groupIdLength = Math.max(groupIdLength, hpi.getGroupId().length());
                 versionLength = Math.max(versionLength, hpi.getVersion().length());
             }
 
@@ -140,25 +226,70 @@ public class BundlePluginsMojo extends AbstractJenkinsMojo {
             });
 
             File list = new File(project.getBuild().getOutputDirectory(), "bundled-plugins.txt");
+            File manifest = new File(project.getBuild().getDirectory(), "plugin-manifest.txt");
             list.getParentFile().mkdirs();
             PrintWriter w = new PrintWriter(list);
+            PrintWriter m = new PrintWriter(manifest);
             try {
+                final String format = "%" + (-artifactIdLength) + "s %" + (-versionLength) + "s %-8s %"+(-groupIdLength)+"s";
+                final String format2 = "%"+(-groupIdLength)+"s %" + (-artifactIdLength) + "s %" + (-versionLength) + "s %-8s%n";
+                getLog().info(String.format(format, 
+                        "Artifact ID", 
+                        "Version", 
+                        "Optional", 
+                        "Group ID"));
+                m.printf(format2, "Group Id", "Artifact Id", "Version", "Optional");
+                m.printf(format2, StringUtils.repeat("=",groupIdLength), StringUtils.repeat("=",artifactIdLength), StringUtils.repeat("=",versionLength), StringUtils.repeat("=",8));
+                getLog().info(String.format(format,
+                        StringUtils.repeat("=", artifactIdLength),
+                        StringUtils.repeat("=", versionLength),
+                        StringUtils.repeat("=", 8),
+                        StringUtils.repeat("=", groupIdLength)));
                 for (MavenArtifact hpi : hpis) {
-                    getLog().info(String.format("%" + (-artifactIdLength) + "s    %" + (-versionLength) + "s    %s",
-                            hpi.getArtifactId(), hpi.getVersion(), hpi.getGroupId()));
+                    getLog().info(String.format(format,
+                            hpi.getArtifactId(), 
+                            hpi.getVersion(), 
+                            nonOptional.contains(hpi.getArtifactId()) ? "" : "optional", 
+                            hpi.getGroupId()));
+                    m.printf(format2,
+                            hpi.getGroupId(),
+                            hpi.getArtifactId(),
+                            hpi.getVersion(),
+                            nonOptional.contains(hpi.getArtifactId()) ? "no" : "yes"
+                    );
                     w.println(hpi.getId());
                 }
             } finally {
                 IOUtils.closeQuietly(w);
+                IOUtils.closeQuietly(m);
             }
 
             projectHelper.attachArtifact(project, "txt", "bundled-plugins", list);
+            projectHelper.attachArtifact(project, "txt", "plugin-manifest", manifest);
         } catch (ArtifactResolutionException e) {
             throw new MojoExecutionException("Failed to resolve plugin dependencies", e);
         } catch (ArtifactNotFoundException e) {
             throw new MojoExecutionException("Failed to resolve plugin dependencies", e);
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to resolve plugin dependencies", e);
+        }
+    }
+    
+    private static class OptionalFilter extends AbstractArtifactsFilter {
+        private final boolean optional;
+
+        private OptionalFilter(boolean optional) {
+            this.optional = optional;
+        }
+
+        public Set filter(Set artifacts) {
+            Set<Artifact> result = new LinkedHashSet<Artifact>();
+            for (Artifact a: (Set<Artifact>)artifacts) {
+                if (optional == a.isOptional()) {
+                    result.add(a);
+                }
+            }
+            return result;
         }
     }
 }


### PR DESCRIPTION
*NOTE:* currently Jenkins core does not understand optionally bundled plugins, so either a module or a plugin would need to extract them somehow

@reviewbybees