### PR TITLE
${basedir}/target/generated-test-sources/injected/

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
@@ -59,7 +59,7 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
         }
 
         try {
-            File f = new File(project.getBasedir(), "target/inject-tests");
+            File f = new File(project.getBasedir(), "target/generated-test-sources/injected");
             f.mkdirs();
             File javaFile = new File(f, injectedTestName + ".java");
             PrintWriter w = new PrintWriter(new OutputStreamWriter(new FileOutputStream(javaFile)));


### PR DESCRIPTION
For consistency with other Maven plugins. NetBeans will recognize it at this location, for example.

@reviewbybees