### PR TITLE
Implement SimpleBuildStep on sample builder

### DIFF
--- a/hpi-archetype/src/main/java/HelloWorldBuilder.java
+++ b/hpi-archetype/src/main/java/HelloWorldBuilder.java
@@ -1,11 +1,15 @@
 import hudson.Launcher;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.util.FormValidation;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -31,7 +35,7 @@ import java.io.IOException;
  *
  * @author Kohsuke Kawaguchi
  */
-public class HelloWorldBuilder extends Builder {
+public class HelloWorldBuilder extends Builder implements SimpleBuildStep {
 
     private final String name;
 
@@ -49,7 +53,7 @@ public class HelloWorldBuilder extends Builder {
     }
 
     @Override
-    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+    public void perform(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) {
         // This is where you 'build' the project.
         // Since this is a dummy, we just say 'hello world' and call that a build.
 
@@ -58,7 +62,6 @@ public class HelloWorldBuilder extends Builder {
             listener.getLogger().println("Bonjour, "+name+"!");
         else
             listener.getLogger().println("Hello, "+name+"!");
-        return true;
     }
 
     // Overridden for better type safety.

--- a/hpi-archetype/src/main/java/HelloWorldBuilder.java
+++ b/hpi-archetype/src/main/java/HelloWorldBuilder.java
@@ -2,8 +2,6 @@ import hudson.Launcher;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.util.FormValidation;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -30,8 +28,7 @@ import java.io.IOException;
  * to remember the configuration.
  *
  * <p>
- * When a build is performed, the {@link #perform(AbstractBuild, Launcher, BuildListener)}
- * method will be invoked. 
+ * When a build is performed, the {@link #perform} method will be invoked. 
  *
  * @author Kohsuke Kawaguchi
  */


### PR DESCRIPTION
See [discussion](https://groups.google.com/d/msg/jenkinsci-dev/0dqXhbjRhYs/AAY6RUn6AgAJ).

With this change, if you create the sample project, `hpi:run` it, and install _Workflow: Aggregator_, _Snippet Generator_ suggests

```groovy
node {
  step([$class: 'HelloWorldBuilder', name: 'Bob'])
}
```

(well, without the required `node` context but that is another matter) and this works.

@reviewbybees