### PR TITLE
Maven 3 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <openbracket>{</openbracket>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>6</java.level>
+    <maven.version>3.0.5</maven.version>
   </properties>
 
   <repositories>
@@ -100,12 +101,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.2.0</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.0</version>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -115,7 +116,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.2.0</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.maven.plugins.hpi;
 
+import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -13,8 +13,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.MavenProjectHelper;
-
-import java.util.List;
+import org.sonatype.aether.impl.ArtifactResolver;
 
 /**
  * Mojos that need to figure out the Jenkins version it's working with.

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/BundlePluginsMojo.java
@@ -3,11 +3,9 @@ package org.jenkinsci.maven.plugins.hpi;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.resolver.ArtifactCollector;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -35,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.sonatype.aether.impl.ArtifactResolver;
 
 /**
  * Take the current project, list up all the transitive dependencies, then copy them

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -1,22 +1,20 @@
 package org.jenkinsci.maven.plugins.hpi;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 import org.apache.maven.artifact.Artifact;
+import static org.apache.maven.artifact.Artifact.*;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.kohsuke.stapler.framework.io.IOException2;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
-import static org.apache.maven.artifact.Artifact.*;
+import org.sonatype.aether.impl.ArtifactResolver;
 
 /**
  * {@link Artifact} is a bare data structure without any behavior and therefore


### PR DESCRIPTION
@stephenc do you know of any guide for replacing Maven 2.x API calls? I am finding it close to impenetrable.

Motivation: I found a plugin whose `dependency:tree` shows the expected version of a plugin included as a transitive dependency, yet `hpi:run` copies an older—and incompatible—version to `work/plugins/`. I suspect this is due to `RunMojo` calling 2.x APIs rather than Aether to find what to pass to `copyPlugin`.
