### PR TITLE
[JENKINS-23378] update to Jetty9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.jenkins-ci.tools</groupId>
   <artifactId>maven-hpi-plugin</artifactId>
-  <version>1.115</version>
+  <version>1.116-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Maven Jenkins Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/maven-hpi-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/maven-hpi-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/maven-hpi-plugin</url>
-    <tag>maven-hpi-plugin-1.115</tag>
+    <tag>HEAD</tag>
   </scm>
   <ciManagement>
     <system>jenkins</system>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dollar>$</dollar>
     <openbracket>{</openbracket>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.2</version>
+      <version>3.4</version>
       <!-- annotations are not needed for plugin execution, so exclude using provided scope -->
       <scope>provided</scope>
     </dependency>
@@ -243,7 +243,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.4</version>
         <configuration>
           <goalPrefix>hpi</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -335,7 +335,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.4</version>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.jenkins-ci.tools</groupId>
   <artifactId>maven-hpi-plugin</artifactId>
-  <version>1.115-SNAPSHOT</version>
+  <version>1.115</version>
   <packaging>maven-plugin</packaging>
 
   <name>Maven Jenkins Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/maven-hpi-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/maven-hpi-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/maven-hpi-plugin</url>
-    <tag>HEAD</tag>
+    <tag>maven-hpi-plugin-1.115</tag>
   </scm>
   <ciManagement>
     <system>jenkins</system>

--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,9 @@
       <version>2.2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-maven-plugin</artifactId>
-      <version>8.1.16.v20140903</version>
+      <version>9.2.15.v20160210</version>
     </dependency>
     <dependency>
       <groupId>net.java.sezpoz</groupId>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
@@ -151,34 +151,6 @@ public abstract class AbstractJettyMojo extends AbstractMojo
 
 
     /**
-     * The context path for the webapp. Defaults to the
-     * name of the webapp's artifact.
-     *
-     * @deprecated Use &lt;webApp&gt;&lt;contextPath&gt; instead.
-     * @parameter expression="/${project.artifactId}"
-     * @required
-     * @readonly
-     */
-    @Parameter(readonly = true, required = true, defaultValue = "/${project.artifactId}")
-    protected String contextPath;
-
-
-    /**
-     * The temporary directory to use for the webapp.
-     * Defaults to target/tmp.  
-     *
-     * @deprecated Use %lt;webApp&gt;&lt;tempDirectory&gt; instead.
-     * @parameter expression="${project.build.directory}/tmp"
-     * @required
-     * @readonly
-     */
-    @Deprecated
-    @Parameter(defaultValue = "${project.build.directory}/tmp", required = true, readonly = true)
-    protected File tmpDirectory;
-
-
-
-    /**
      * The interval in seconds to scan the webapp for changes 
      * and restart the context if necessary. Ignored if reload
      * is enabled. Disabled by default.

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -32,15 +32,17 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
+import org.eclipse.jetty.maven.plugin.JettyWebAppContext;
+import org.eclipse.jetty.maven.plugin.MavenServerConnector;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.mortbay.jetty.plugin.JettyServer;
-import org.mortbay.jetty.plugin.JettyWebAppContext;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -141,7 +144,7 @@ public class RunMojo extends AbstractJettyMojo {
      * If connectors are configured in the Mojo, that'll take precedence.
      */
     @Parameter(property = "port")
-    protected String defaultPort;
+    protected int defaultPort;
 
     /**
      * If true, the context will be restarted after a line feed on
@@ -206,6 +209,18 @@ public class RunMojo extends AbstractJettyMojo {
     private Map<String,String> loggers;
 
     private Collection<Logger> loggerReferences; // just to prevent GC
+
+    /**
+     * The context path for the webapp. Defaults to the
+     * name of the webapp's artifact.
+     *
+     * @deprecated Use &lt;webApp&gt;&lt;contextPath&gt; instead.
+     * @parameter expression="/${project.artifactId}"
+     * @required
+     * @readonly
+     */
+    @Parameter(readonly = true, required = true, defaultValue = "/${project.artifactId}")
+    protected String contextPath;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         getProject().setArtifacts(resolveDependencies(dependencyResolution));
@@ -422,7 +437,9 @@ public class RunMojo extends AbstractJettyMojo {
 
     public void configureWebApplication() throws Exception {
         // Jetty tries to do this in WebAppContext.resolveWebApp but it failed to delete the directory.
-        File extractedWebAppDir= new File(getTmpDirectory(), "webapp");
+        File t = webApp.getTempDirectory();
+        if (t==null)    t = new File(getProject().getBuild().getDirectory(),"tmp");
+        File extractedWebAppDir= new File(t, "webapp");
         if (isExtractedWebAppDirStale(extractedWebAppDir, webAppFile)) {
             FileUtils.deleteDirectory(extractedWebAppDir);
         }
@@ -433,6 +450,16 @@ public class RunMojo extends AbstractJettyMojo {
         HashLoginService hashLoginService = (new HashLoginService("Jenkins Realm"));
         hashLoginService.setConfig(System.getProperty("jetty.home", "work") + "/etc/realm.properties");
         getWebAppConfig().getSecurityHandler().setLoginService(hashLoginService);
+
+        // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
+        for (Connector con : server.getConnectors()) {
+            for (ConnectionFactory cf : con.getConnectionFactories()) {
+                if (cf instanceof HttpConnectionFactory) {
+                    HttpConnectionFactory hcf = (HttpConnectionFactory) cf;
+                    hcf.getHttpConfiguration().setResponseHeaderSize(12*1024);
+                }
+            }
+        }
     }
 
     private static final String VERSION_PATH = "META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties";
@@ -490,6 +517,7 @@ public class RunMojo extends AbstractJettyMojo {
         getLog().info(extractedWebAppDir + " already up to date with respect to " + webApp);
         return false;
     }
+
     private String loadVersion(InputStream is) throws IOException {
         Properties props = new Properties();
         props.load(is);
@@ -497,10 +525,10 @@ public class RunMojo extends AbstractJettyMojo {
     }
 
     public void configureScanner() throws MojoExecutionException {
-        setUpScanList(new ArrayList<File>());
+        setUpScanList();
 
-        ArrayList<Scanner.BulkListener> listeners = new ArrayList<Scanner.BulkListener>();
-        listeners.add(new Scanner.BulkListener() {
+        scannerListeners = new ArrayList<Scanner.BulkListener>();
+        scannerListeners.add(new Scanner.BulkListener() {
             public void filesChanged(List<String> changes) {
                 try {
                     restartWebApp(changes.contains(getProject().getFile().getCanonicalPath()));
@@ -509,40 +537,49 @@ public class RunMojo extends AbstractJettyMojo {
                 }
             }
         });
-        setScannerListeners(listeners);
-
     }
 
     @Override
     public void restartWebApp(boolean reconfigureScanner) throws Exception {
-        getLog().info("Restarting webapp ...");
+        getLog().info("restarting "+webApp);
         getLog().debug("Stopping webapp ...");
-        getWebAppConfig().stop();
+        webApp.stop();
         getLog().debug("Reconfiguring webapp ...");
 
         checkPomConfiguration();
+        configureWebApplication();
 
         // check if we need to reconfigure the scanner,
         // which is if the pom changes
-        if (reconfigureScanner) {
+        if (reconfigureScanner)
+        {
             getLog().info("Reconfiguring scanner after change to pom.xml ...");
             generateHpl(); // regenerate hpl if POM changes.
-            ArrayList<File> scanList = getScanList();
+
             scanList.clear();
-            setUpScanList(scanList);
-            getScanner().setScanDirs(scanList);
+            if (webApp.getDescriptor() != null)
+                scanList.add(new File(webApp.getDescriptor()));
+            if (webApp.getJettyEnvXml() != null)
+                scanList.add(new File(webApp.getJettyEnvXml()));
+            scanList.add(project.getFile());
+            if (webApp.getTestClasses() != null)
+                scanList.add(webApp.getTestClasses());
+            if (webApp.getClasses() != null)
+            scanList.add(webApp.getClasses());
+            scanList.addAll(webApp.getWebInfLib());
+            scanner.setScanDirs(scanList);
         }
 
         getLog().debug("Restarting webapp ...");
-        getWebAppConfig().start();
-        getLog().info("Restart completed.");
+        webApp.start();
+        getLog().info("Restart completed at " + new Date().toString());
     }
 
-    private void setUpScanList(ArrayList<File> scanList) {
+    private void setUpScanList() {
+        scanList = new ArrayList<File>();
         scanList.add(getProject().getFile());
         scanList.add(webAppFile);
         scanList.add(new File(getProject().getBuild().getOutputDirectory()));
-        setScanList(scanList);
     }
 
     @Override
@@ -612,19 +649,13 @@ public class RunMojo extends AbstractJettyMojo {
         }
     }
 
-    public JettyServer createServer() throws Exception {
-        return new JettyServer() {
-            @Override
-            public Connector createDefaultConnector(String portnum) throws Exception {
-                if ((portnum == null || portnum.equals("")) && defaultPort != null) {
-                    portnum = defaultPort;
-                }
-                SelectChannelConnector con = (SelectChannelConnector)super.createDefaultConnector(portnum);
-                con.setResponseHeaderSize(12*1024);// use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
-
-                return con;
-            }
-        };
+    @Override
+    public void startJetty() throws MojoExecutionException {
+        if (httpConnector==null && defaultPort!=0) {
+            httpConnector = new MavenServerConnector();
+            httpConnector.setPort(defaultPort);
+        }
+        super.startJetty();
     }
 
     /**
@@ -689,5 +720,14 @@ public class RunMojo extends AbstractJettyMojo {
             );
         }
         throw new MojoExecutionException("Unable to find jenkins.war");
+    }
+
+    protected MavenProject getProject() {
+        return project;
+    }
+
+
+    public WebAppContext getWebAppConfig() {
+        return webApp;
     }
 }


### PR DESCRIPTION
`hpi:run` should run Jetty 9.2 to support Servlet 3.1.

I've fixed how we track upstream files from jetty-maven-plugin so that future merges like this will be more manageable.

The diff view in this PR mixes upstream changes in Jetty and local changes, which is useless. If you want to really understand the diff, look at `git log -U jetty9.2 '^incoming' '^master'`

@reviewbybees 