### PR TITLE
We must use runtime scope for work/plugins/$p.hpl

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -420,7 +420,7 @@ public class RunMojo extends AbstractJettyMojo {
         hpl.setLog(getLog());
         hpl.pluginName = getProject().getName();
         hpl.warSourceDirectory = warSourceDirectory;
-        hpl.scopeFilter = new ScopeArtifactFilter(dependencyResolution);
+        hpl.scopeFilter = new ScopeArtifactFilter("runtime");
         hpl.projectBuilder = this.projectBuilder;
         hpl.localRepository = this.localRepository;
         hpl.jenkinsCoreId = this.jenkinsCoreId;


### PR DESCRIPTION
Without this fix,

    mvn -f maven-plugin hpi:run

fails with

```
… hudson.PluginManager$1$3$2$1 reactOnCycle
SEVERE: found cycle in plugin dependencies: (root=Plugin:maven-plugin, deactivating all involved) Plugin:maven-plugin -> Plugin:promoted-builds -> Plugin:maven-plugin
```

Same for the problem identified in https://github.com/jenkinsci/junit-plugin/pull/31.

@reviewbybees esp. @andresrc, @emanuelez