### PR TITLE
Sort artifacts so that Plugin-Dependencies appears in a consistent order from build to build

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -26,8 +26,6 @@ import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.model.Resource;
 import org.apache.maven.model.Developer;
@@ -35,8 +33,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
-import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.jar.Manifest;
@@ -75,6 +71,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Collection;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -457,7 +454,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
     }
 
     protected Set<MavenArtifact> wrap(Iterable<Artifact> artifacts) {
-        Set<MavenArtifact> r = new HashSet<MavenArtifact>();
+        Set<MavenArtifact> r = new TreeSet<>();
         for (Artifact a : artifacts) {
             r.add(wrap(a));
         }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -26,7 +26,7 @@ import static org.apache.maven.artifact.Artifact.*;
  *
  * @author Kohsuke Kawaguchi
  */
-public class MavenArtifact {
+public class MavenArtifact implements Comparable<MavenArtifact> {
     public final ArtifactFactory artifactFactory;
     public final MavenProjectBuilder builder;
     public final List<ArtifactRepository> remoteRepositories;
@@ -151,6 +151,11 @@ public class MavenArtifact {
     @Override
     public String toString() {
         return getId();
+    }
+
+    @Override
+    public int compareTo(MavenArtifact o) {
+        return getId().compareTo(o.getId());
     }
 
     /**


### PR DESCRIPTION
While trying to track down what might have gotten broken in a plugin snapshot build, I noticed that the order of `Plugin-Dependencies` was random. Making it deterministic.

(Note that currently the primary sort key is effectively `groupId`, which means that from the perspective of plugin `shortName`s the list is not lexicographically sorted, though it _is_ deterministic.)

@reviewbybees