### PR TITLE
Parse Short-Name & Plugin-Version out of the actual plugin manifest

### DIFF
--- a/src/it/jitpack/invoker.properties
+++ b/src/it/jitpack/invoker.properties
@@ -1,0 +1,4 @@
+# install, not verify, because we want to check the artifact as we would be about to deploy it
+# !enforcer.fail to suppress (TODO do in plugin-pom/pom.xml via requirePluginVersions#unCheckedPluginList): Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed ) \\ [INFO] org.jenkins-ci.tools:maven-hpi-plugin. The version currently in use is 1.xyz-SNAPSHOT
+# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
+invoker.goals=-Pjenkins-release -Denforcer.fail=false -Drelease.skipTests=false clean install

--- a/src/it/jitpack/pom.xml
+++ b/src/it/jitpack/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>2.19</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>jitpack</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>1.609.3</jenkins.version>
+        <java.level>6</java.level>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.jenkinsci</groupId>
+            <artifactId>scm-api-plugin</artifactId>
+            <version>8aa91ab</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/jitpack/src/main/java/test/C.java
+++ b/src/it/jitpack/src/main/java/test/C.java
@@ -1,0 +1,9 @@
+package test;
+
+import jenkins.scm.api.metadata.ObjectMetadataAction;
+
+public class C {
+    ObjectMetadataAction action() {
+        return new ObjectMetadataAction("Test", null, null);
+    }
+}

--- a/src/it/jitpack/src/main/resources/index.jelly
+++ b/src/it/jitpack/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/jitpack/src/test/java/test/CTest.java
+++ b/src/it/jitpack/src/test/java/test/CTest.java
@@ -1,0 +1,18 @@
+package test;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void displayName() throws Exception {
+        assertEquals("Test", new C().action().getObjectDisplayName());
+    }
+
+}

--- a/src/it/jitpack/verify.groovy
+++ b/src/it/jitpack/verify.groovy
@@ -1,0 +1,13 @@
+import java.util.jar.*
+
+File hpi = new File(basedir, '../../local-repo/org/jenkins-ci/tools/hpi/its/jitpack/1.0-SNAPSHOT/jitpack-1.0-SNAPSHOT.hpi')
+assert hpi.file
+JarFile j = new JarFile(hpi)
+try {
+    Attributes attr = j.manifest.mainAttributes
+    assert attr.getValue('Plugin-Dependencies') == 'scm-api:2.0.1-SNAPSHOT'
+} finally {
+    j.close()
+}
+
+return true

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -27,7 +27,7 @@ under the License.
       <id>mrm-maven-plugin</id>
       <name>Mock Repository Manager</name>
       <url>@repository.proxy.url@</url>
-      <mirrorOf>*</mirrorOf>
+      <mirrorOf>*,!jitpack.io</mirrorOf>
     </mirror>
   </mirrors>
   <profiles>


### PR DESCRIPTION
Ignoring the GAV used to express the dependency. Seems to fix a problem in the contents of `Plugin-Dependencies` in `target/test-classes/the.hpl` and `target/*.hpi` when using jitpack.io as in https://github.com/jenkinsci/plugin-pom/pull/37.

Possibly other uses of dependency GAVs are also wrong, say in the `run` goal (?), but this is the one I noticed for now.

@reviewbybees