### PR TITLE
New Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+node('docker') {
+  checkout scm
+  docker.image('maven:3.3.9-jdk-8').inside {
+    sh 'mvn -B -Prun-its clean install'
+  }
+  /* Useful for debugging failures, but currently too big (~25Mb):
+  archiveArtifacts 'target/its/*/build.log'
+  */
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
 node('docker') {
   checkout scm
   docker.image('maven:3.3.9-jdk-8').inside {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ node('docker') {
   docker.image('maven:3.3.9-jdk-8').inside {
     sh 'mvn -B -Prun-its clean install'
   }
-  /* Useful for debugging failures, but currently too big (~25Mb):
-  archiveArtifacts 'target/its/*/build.log'
-  */
+  // Useful for debugging failures, but currently too big (~25Mb):
+  // archiveArtifacts 'target/its/*/build.log'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,12 @@
 node('docker') {
   checkout scm
   docker.image('maven:3.3.9-jdk-8').inside {
-    sh 'mvn -B -Prun-its clean install'
+    try {
+      sh 'mvn -B -Prun-its clean install'
+    } catch (e) {
+      // Too big (~25Mb) to archive for successful builds:
+      archiveArtifacts artifacts: 'target/its/*/build.log', allowEmptyArchive: true
+      throw e
+    }
   }
-  // Useful for debugging failures, but currently too big (~25Mb):
-  // archiveArtifacts 'target/its/*/build.log'
 }


### PR DESCRIPTION
@reviewbybees esp. @rtyler who should please create a ci.jenkins.io job for this, to replace [`Libraries/maven-hpi-plugin`](https://ci.jenkins.io/job/Libraries/job/maven-hpi-plugin/) using the Evil Job Type.

Once there is a home, the *Build Status* link in `README.md` could be updated (or just deleted—we expect `master` to always be a blue ball, right?).