### PR TITLE
More fixes to mojos that assumed that plugin artifacts used a short name identical to the artifactId

### DIFF
--- a/src/it/jitpack/verify.groovy
+++ b/src/it/jitpack/verify.groovy
@@ -10,4 +10,8 @@ try {
     j.close()
 }
 
+File testDependencies = new File(basedir, 'target/test-classes/test-dependencies')
+assert new File(testDependencies, 'index').text.trim() == 'scm-api'
+assert new TreeSet<String>(Arrays.asList(testDependencies.list())).toString() == '[index, scm-api.hpi]'
+
 return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -72,8 +72,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Collection;
 import java.util.TreeSet;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -1033,13 +1031,9 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
             if(a.isPlugin() && scopeFilter.include(a.artifact) && !a.hasSameGAAs(project)) {
                 if(buf.length()>0)
                     buf.append(',');
-                // Do not rely on a.artifactId/version since that will be nonsense in the case of jitpack.io, for example.
-                try (JarFile jf = new JarFile(a.getFile())) { // TODO possibly this should be moved into MavenArtifact
-                    Attributes attr = jf.getManifest().getMainAttributes();
-                    buf.append(attr.getValue("Short-Name"));
-                    buf.append(':');
-                    buf.append(attr.getValue("Plugin-Version").replaceFirst(" [(].+[)]$", "")); // e.g. " (private-abcd1234-username)"; Implementation-Version is clean but seems less portable
-                }
+                buf.append(a.getActualArtifactId());
+                buf.append(':');
+                buf.append(a.getActualVersion());
                 if (a.isOptional()) {
                     buf.append(";resolution:=optional");
                 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.framework.io.IOException2;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.jar.JarFile;
 
 import static org.apache.maven.artifact.Artifact.*;
 
@@ -125,12 +126,32 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
         return false;
     }
 
+    /** Gets the {@code artifactId} as used in a dependency declaration. For a plugin artifact this need not be be a plugin short name. */
     public String getArtifactId() {
         return artifact.getArtifactId();
     }
 
+    /** Gets the {@code version} as used in a dependency declaration. For a plugin artifact this need not be be a plugin version number. */
     public String getVersion() {
         return artifact.getVersion();
+    }
+
+    public String getClassifier() {
+        return artifact.getClassifier();
+    }
+
+    /** For a plugin artifact, unlike {@link #getArtifactId} this parses the plugin manifest. */
+    public String getActualArtifactId() throws IOException {
+        try (JarFile jf = new JarFile(getFile())) {
+            return jf.getManifest().getMainAttributes().getValue("Short-Name");
+        }
+    }
+
+    /** For a plugin artifact, unlike {@link #getVersion} this parses the plugin manifest. */
+    public String getActualVersion() throws IOException {
+        try (JarFile jf = new JarFile(getFile())) {
+            return jf.getManifest().getMainAttributes().getValue("Plugin-Version").replaceFirst(" [(].+[)]$", ""); // e.g. " (private-abcd1234-username)"; Implementation-Version is clean but seems less portable
+        }
     }
 
     public ArtifactVersion getVersionNumber() throws OverConstrainedVersionException {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -328,9 +328,9 @@ public class RunMojo extends AbstractJettyMojo {
 
                 File upstreamHpl = pluginWorkspaceMap.read(hpi.getId());
                 if (upstreamHpl != null) {
-                    copyHpl(upstreamHpl, pluginsDir, a.getArtifactId());
+                    copyHpl(upstreamHpl, pluginsDir, a.getActualArtifactId());
                 } else {
-                    copyPlugin(hpi.getFile(), pluginsDir, a.getArtifactId());
+                    copyPlugin(hpi.getFile(), pluginsDir, a.getActualArtifactId());
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -33,10 +33,16 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 if(!a.isPlugin())
                     continue;
 
-                getLog().debug("Copying "+a.getId()+" as a test dependency");
-                File dst = new File(testDir, a.getArtifactId() + ".hpi");
+                String artifactId = a.getActualArtifactId();
+                if (artifactId == null) {
+                    getLog().debug("Skipping " + artifactId + " with classifier " + a.getClassifier());
+                    continue;
+                }
+
+                getLog().debug("Copying " + artifactId + " as a test dependency");
+                File dst = new File(testDir, artifactId + ".hpi");
                 FileUtils.copyFile(a.getHpi().getFile(),dst);
-                w.write(a.getArtifactId()+"\n");
+                w.write(artifactId + "\n");
             }
 
             w.close();


### PR DESCRIPTION
Follows up #46.

@reviewbybees