### PR TITLE
[JENKINS-41531] Ignore blank values for compatibleSinceVersion explicitly

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -931,7 +931,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         if(url!=null)
             mainSection.addAttributeAndCheck(new Attribute("Url", url));
 
-        if (compatibleSinceVersion!=null)
+        if (StringUtils.isNotBlank(compatibleSinceVersion))
             mainSection.addAttributeAndCheck(new Attribute("Compatible-Since-Version", compatibleSinceVersion));
 
         if (sandboxStatus!=null)


### PR DESCRIPTION
[JENKINS-41531](https://issues.jenkins-ci.org/browse/JENKINS-41531)
jenkinsci/plugin-pom#43

I plan to specify `compatibleSinceVersion` with a property like:
```
  <properties>
    <hpi-plugin.compatibleSinceVersion>1.0</hpi-plugin.compatibleSinceVersion>
  </properties>
  <build>
    <plugins>
      <plugin>
        <groupId>org.jenkins-ci.tools</groupId>
        <artifactId>maven-hpi-plugin</artifactId>
        <extensions>true</extensions>
        <configuration>
          <compatibleSinceVersion>${hpi-plugin.compatibleSinceVersion}</compatibleSinceVersion>
        </configuration>
      </plugin>
    </plugins>
  </build>
```

I want not specifying `hpi-plugin.compatibleSinceVersion` results just as not specifying `configuration/compatibleSinceVersion`.
maven looks treat blank values as `null`, and that's the behavior I expect.
But I couldn't find a document about that behavior, and I'm not sure that's a designated specification of maven and maven continue to behave as so in future versions.
(MEXEC-104, http://mojo.10943.n7.nabble.com/jira-Created-MEXEC-104-Cannot-pass-empty-argument-to-exec-goal-td17960.html)

This change ensures that maven-hpi-plugin ignores blank values for `compatibleSinceVersion`.
