### PR TITLE
Allow setting of context path

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -213,10 +213,8 @@ public class RunMojo extends AbstractJettyMojo {
     /**
      * The context path for the webapp. Defaults to the
      * name of the webapp's artifact.
-     *
-     * @deprecated Use &lt;webApp&gt;&lt;contextPath&gt; instead.
      */
-    @Parameter(readonly = true, required = true, defaultValue = "/${project.artifactId}")
+    @Parameter(required = true, defaultValue = "/${project.artifactId}")
     protected String contextPath;
 
     @Component

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -227,7 +227,6 @@ public class RunMojo extends AbstractJettyMojo {
 
         if (webApp == null || webApp.getContextPath() == null) {
             if (contextPath != null) {
-                getLog().warn("Please use `webApp/contextPath` configuration parameter in place of the deprecated `contextPath` parameter");
                 if (webApp == null) {
                     try {
                         webApp = new JettyWebAppContext();


### PR DESCRIPTION
You cant deprecate `contextPath` for `webApp.contextPath` because `webApp` object gets created during the 'execute' method and when maven tries to set it, its null.

This PR just restores the functionality lost. If someone wants it to work the way it was previously advertised they should but this would get Blue Ocean devs out of a productivity hole.

@reviewbybees 