### PR TITLE
cover the case when plugin.version.description property is set to empty string in pom.xml

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -942,7 +942,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
                 dt = new SimpleDateFormat("MM/dd/yyyy HH:mm").format(new Date());
             pluginVersionDescription = "private-"+dt+"-"+System.getProperty("user.name");
         }
-        if (pluginVersionDescription!=null)
+        if (pluginVersionDescription!=null && !pluginVersionDescription.trim().isEmpty())
             v += " (" + pluginVersionDescription + ")";
 
         if (!project.getPackaging().equals("jenkins-module")) {


### PR DESCRIPTION
Thanks much. 
This has to do with https://github.com/jenkinsci/docker/blob/master/install-plugins.sh. That is how I found it. This script takes space separated list of plugins to automatically install during docker image build. And the maven hpi package adds a space if it is a SNAPSHOT version in MANIFEST.MF "(Plugin-Version: 2.0.5-SNAPSHOT (githash-user/timestamp)", so the scripts thinks there are two plugins to install and fails.  If one explicitly puts quotes around the plugin name it still works. But you have to call it separately from other plugin install. Otherway might be to add another maven property to remove the space in before "(". But the cureent property can be effectively used the way developer wants it.

<properties>
<!-- for MANIFEST.MF so it doesn't add (githash-user) to Plugin-Version:
${version} -->
<plugin.version.description></plugin.version.description>
</properties>