### PR TITLE
Publish plugin manifest as an artifact

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -17,7 +17,10 @@ package org.jenkinsci.maven.plugins.hpi;
  */
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
@@ -159,6 +162,13 @@ public class HpiMojo extends AbstractHpiMojo {
 
         // generate war file
         buildExplodedWebapp(getWebappDirectory(),jarFile);
+
+        File hpiMfFile = getOutputFile(".hpi.mf");
+        getLog().info("Archiving hpi manifest" + hpiMfFile.getAbsolutePath());
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(hpiMfFile), "UTF-8"))) {
+            manifest.write(printWriter);
+        }
+        projectHelper.attachArtifact(project, "hpi.mf", null, hpiMfFile);
 
         File hpiFile = getOutputFile(".hpi");
         getLog().info("Generating hpi " + hpiFile.getAbsolutePath());


### PR DESCRIPTION
This pull request is a proposal to publish the manifest included inside the HPI file of a plugin as a separate artifact.

The rationale behind this is to simplify the building of new tools dealing with plugins. It is for example quite difficult to write an off-line plugin bundler right now, as there is no way to list the dependencies of a plugin easily:

* update center JSON file only contains the dependencies of the latest version of each plugin. Dependencies of previous versions are not available
* even if dependencies are available in the POM file, this requires Maven to extract the dependencies graph. Tools we want to build are not always running as a Maven plugin

The [update center updater code](https://github.com/jenkins-infra/backend-update-center2) relies
on the content of this manifest to work, hence it downloads all plugins to be able to generate the JSON update center file (correct me if I'm wrong here, but that's what I understood from the codebase).

There's currently multiple situation where we are working around this situation:

* the official Jenkins docker image offers a [script to bundle plugins](https://github.com/jenkinsci/docker/blob/master/install-plugins.sh) during the creation of an image but people are complaining their builds are not reproducible (which is the reason why BlueOcean image is not using it). The problem is that this script can only download latest plugin version of plugin dependencies.
* BlueOcean is publishing a Docker image with BO plugins bundled and uses [Maven with a fake POM to bundle them](https://github.com/jenkinsci/blueocean-plugin/blob/master/docker/official/pom.xml#L45) instead of the script available in the Docker image

With regard to the Docker script, I already discussed the issue and proposed to use Maven with a fake POM but [this was not seen as a good solution](https://github.com/jenkinsci/docker/issues/327#issuecomment-240022912). It was for sure not a clean one.

At CloudBees, we have internal tooling which has to deal with the situation and having those manifests available would be really helpful. I'm sure there are other examples in the community where having these manifests would be very helpful too. Any tool dealing with plugins needs that information and there's currently no easy way to extract it.

I know it's going to take a long time to have all the manifests published for all plugins but this problem has to be addressed at some point. I wonder if it could be possible to retroactively publish them, btw.

I'm happy to hear what you think about this proposal.

@reviewbybees cc @i386 @aheritier @alecharp @daniel-beck @stephenc 