### PR TITLE
Add log for current artifact under test

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
@@ -116,6 +116,7 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
             w.println(" */");
             w.println("public class " + injectedTestName + " extends junit.framework.TestCase {");
             w.println("  public static junit.framework.Test suite() throws Exception {");
+            w.println("    System.out.println(\"Running tests for \"+" + quote(project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion())+");");
             w.println("    Map parameters = new HashMap();");
             w.println("    parameters.put(\"basedir\","+quote(project.getBasedir().getAbsolutePath())+");");
             w.println("    parameters.put(\"artifactId\","+quote(project.getArtifactId())+");");


### PR DESCRIPTION
Running many plugin builds in parallel makes identifying failing ones with the current JUnit plugin a pain. This additional log aims at mitigating this a bit waiting for an actual JUnit plugin improvement to subcategorize Jenkins JUnit reporting.

Add the following first line to the `InjectedTest-output.txt` file:

```
Running tests for com.company.group:someplugin:1.2.3-SNAPSHOT
```

@reviewbybees 