### PR TITLE
[JENKINS-43950] Resolve dependencies if jenkins war file does not exist

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -89,14 +89,20 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
      *             if the artifact file can't be resolved
      */
     public File getFile() {
-        if (artifact.getFile()==null)
+        if (artifact.getFile()==null) {
+            if (artifact.isResolved()) {
+                // artifacts can be set as resolved and file be null, is this a bug in Maven 3.5.0 ?
+                artifact.setResolved(false);
+            }
             try {
                 resolver.resolve(artifact, remoteRepositories, localRepository);
             } catch (AbstractArtifactResolutionException e) {
                 throw new RuntimeException("Failed to resolve "+getId(),e);
             }
-        if (artifact.getFile()==null)
+        }
+        if (artifact.getFile()==null) {
             throw new NullPointerException("Unable to resolve file for artifact " + artifact);
+        }
         return artifact.getFile();
     }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -81,6 +81,12 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
 
     /**
      * Resolves to the jar file that contains the code of the plugin.
+     * 
+     * @return the artifact file
+     * @throws RuntimeException
+     *             if the artifact can't be resolved
+     * @throws NullPointerException
+     *             if the artifact file can't be resolved
      */
     public File getFile() {
         if (artifact.getFile()==null)
@@ -89,6 +95,8 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
             } catch (AbstractArtifactResolutionException e) {
                 throw new RuntimeException("Failed to resolve "+getId(),e);
             }
+        if (artifact.getFile()==null)
+            throw new NullPointerException("Unable to resolve file for artifact " + artifact);
         return artifact.getFile();
     }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -725,8 +725,15 @@ public class RunMojo extends AbstractJettyMojo {
                 match = (a.getGroupId()+':'+a.getArtifactId()).equals(jenkinsWarId);
             else
                 match = (a.getArtifactId().equals("jenkins-war") || a.getArtifactId().equals("hudson-war")) && (a.getType().equals("executable-war") || a.getType().equals("war"));
-            if(match)
+            if(match) {
+                if (a.getFile() == null) {
+                    // is this a bug in Maven 3.5.0 ?
+                    getLog().warn(String.format("File for artifact %s not resolved, triggering resolution again", a));
+                    a.setResolved(false);
+                    resolveDependencies("test");
+                }
                 return a;
+            }
         }
 
         if (jenkinsWarId!=null) {


### PR DESCRIPTION
[JENKINS-43950](https://issues.jenkins-ci.org/browse/JENKINS-43950)

Fail fast instead of later on