### PR TITLE
[JENKINS-24064] Replace war-for-test classifier with executable-war type

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -724,7 +724,7 @@ public class RunMojo extends AbstractJettyMojo {
             if (jenkinsWarId!=null)
                 match = (a.getGroupId()+':'+a.getArtifactId()).equals(jenkinsWarId);
             else
-                match = (a.getArtifactId().equals("jenkins-war") || a.getArtifactId().equals("hudson-war")) && a.getType().equals("war");
+                match = (a.getArtifactId().equals("jenkins-war") || a.getArtifactId().equals("hudson-war")) && a.getType().equals("executable-war");
             if(match)
                 return a;
         }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -724,7 +724,7 @@ public class RunMojo extends AbstractJettyMojo {
             if (jenkinsWarId!=null)
                 match = (a.getGroupId()+':'+a.getArtifactId()).equals(jenkinsWarId);
             else
-                match = (a.getArtifactId().equals("jenkins-war") || a.getArtifactId().equals("hudson-war")) && a.getType().equals("executable-war");
+                match = (a.getArtifactId().equals("jenkins-war") || a.getArtifactId().equals("hudson-war")) && (a.getType().equals("executable-war") || a.getType().equals("war"));
             if(match)
                 return a;
         }

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -121,5 +121,19 @@
         <addedToClasspath>true</addedToClasspath>
       </configuration>
     </component>
+    
+    <!-- See JENKINS-24064 for background; used to be war-for-test classifier. -->
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>executable-war</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>executable-war</type>
+        <extension>war</extension>
+        <language>java</language>
+        <addedToClasspath>true</addedToClasspath>
+      </configuration>
+    </component>
+
   </components>
 </component-set>


### PR DESCRIPTION
[JENKINS-24064](https://issues.jenkins-ci.org/browse/JENKINS-24064)

Should allow us to avoid deploying two copies of `jenkins.war`, while simplifying how `WarExploder` finds the WAR file to use.

@reviewbybees