### PR TITLE
Fixing unchecked/rawtypes warnings in InjectedTest

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
@@ -117,7 +117,7 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
             w.println("public class " + injectedTestName + " extends junit.framework.TestCase {");
             w.println("  public static junit.framework.Test suite() throws Exception {");
             w.println("    System.out.println(\"Running tests for \"+" + quote(project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion())+");");
-            w.println("    Map parameters = new HashMap();");
+            w.println("    Map<String, Object> parameters = new HashMap<String, Object>();");
             w.println("    parameters.put(\"basedir\","+quote(project.getBasedir().getAbsolutePath())+");");
             w.println("    parameters.put(\"artifactId\","+quote(project.getArtifactId())+");");
             w.println("    parameters.put(\"packaging\","+quote(project.getPackaging())+");");


### PR DESCRIPTION
Compilability is verified by existing ITs; I did not bother adding an assertion that there are no compiler warnings in the log since this is pretty trivial.

@reviewbybees