### PR TITLE
What's "ea"? Seems arbitrary.

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/VersionNumber.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/VersionNumber.java
@@ -45,10 +45,6 @@ import java.util.StringTokenizer;
  *
  * <h2>Special tokens</h2>
  * <p>
- * We allow a component to be not just a number, but also "ea", "ea1", "ea2".
- * "ea" is treated as "ea0", and eaN &lt; M for any M &gt; 0.
- *
- * <p>
  * '*' is also allowed as a component, and '*' &gt; M for any M &gt; 0.
  *
  * <p>
@@ -87,12 +83,6 @@ public class VersionNumber implements Comparable<VersionNumber> {
                 digits[i-1]--;
                 digits[i++] = 1000;
                 break;
-            } else
-            if(token.startsWith("ea")) {
-                if(token.length()==2)
-                    digits[i++] = -1000;    // just "ea"
-                else
-                    digits[i++] = -1000 + Integer.parseInt(token.substring(2)); // "eaNNN"
             } else {
                 int n =0;
                 try {


### PR DESCRIPTION
I've found this weird especial version number handle.

Sometimes it is a practice to use short hash strings in versions to identify a release number (because, well, why not? At the end for the day it is as valid as a tag). Today it happened I released an internal artifact with version `1.1.5-ea01b41`. Yes, bad luck, really bad luck (didn't calculate the odds, but I bet they really low).

So `mvn hpi:run` in a project depending on the `1.1.5-ea01b41` ends with `java.lang.NumberFormatException`.

It is not my intention to remove this, just to start a discussion about keeping it or not (and found a PR is the best place to discuss it).

@reviewbybees @jenkinsci/code-reviewers 