### PR TITLE
Fix jdk8 javadoc warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Also make sure `project.parent.version` in `src/it/parent-2x/pom.xml` is the lat
 ## Updating Jetty
 `hpi:run` mojo is a variant of `jetty:run` mojo, and because of the way plugin descriptor is generated, this module copies some code from Jetty Maven plugin, specifically `AbstractJettyMojo.java` and `ConsoleScanner.java`.
 
-To keep upstream tracking easier, prestine copies of these files are copied into `incoming-x.y` branch, then package renamed. This version specific incoming branch is then "theirs" merged into the `incoming` branch, which acts as the upstream tracking branch.
+To keep upstream tracking easier, pristine copies of these files are copied into `incoming-x.y` branch, then package renamed. This version specific incoming branch is then "theirs" merged into the `incoming` branch, which acts as the upstream tracking branch.
 
 This branch is then merged into `master` via `git merge -X ignore-space-at-eol incoming`. See diff between `incoming` and `master` on these files to see the exact local patches.

--- a/hpi-archetype/src/main/java/HelloWorldBuilder.java
+++ b/hpi-archetype/src/main/java/HelloWorldBuilder.java
@@ -44,6 +44,7 @@ public class HelloWorldBuilder extends Builder implements SimpleBuildStep {
 
     /**
      * We'll use this from the {@code config.jelly}.
+     * @return name to include in greeting
      */
     public String getName() {
         return name;
@@ -107,6 +108,8 @@ public class HelloWorldBuilder extends Builder implements SimpleBuildStep {
          *      Note that returning {@link FormValidation#error(String)} does not
          *      prevent the form from being saved. It just means that a message
          *      will be displayed to the user. 
+         * @throws java.io.IOException on input / output error
+         * @throws javax.servlet.ServletException on servlet exception
          */
         public FormValidation doCheckName(@QueryParameter String value)
                 throws IOException, ServletException {
@@ -145,6 +148,7 @@ public class HelloWorldBuilder extends Builder implements SimpleBuildStep {
          *
          * The method name is bit awkward because global.jelly calls this method to determine
          * the initial state of the checkbox by the naming convention.
+         * @return true if French language should be used
          */
         public boolean getUseFrench() {
             return useFrench;


### PR DESCRIPTION
I'm preparing an Intro to Plugin Development workshop for Jenkins World 2017.  I found a few javadoc warnings when compiling the plugin with JDK 8.  Since JDK 8 is required at compile time, let's have the javadoc compile without warning.