### PR TITLE
[JENKINS-41196] config flag for core component override.

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -229,6 +229,13 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
     protected boolean pluginFirstClassLoader = false;
 
     /**
+     * True if this is a plugin that overrides a core component.
+     * See https://issues.jenkins-ci.org/browse/JENKINS-41196
+     */
+    @Parameter
+    protected boolean coreComponent = false;
+
+    /**
      * If true, test scope dependencies count as if they are normal dependencies.
      * This is only useful during hpi:run, so not exposing it as a configurable parameter.
      */
@@ -977,6 +984,9 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         Boolean b = isSupportDynamicLoading();
         if (b!=null)
             mainSection.addAttributeAndCheck(new Attribute("Support-Dynamic-Loading",b.toString()));
+
+        if (coreComponent)
+            mainSection.addAttributeAndCheck(new Attribute("Core-Component","true"));
     }
 
     /**
@@ -986,6 +996,10 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
      * we don't know we can dynamic load. Otherwise, if everything is known to be dynamic loadable, return true.
      */
     protected Boolean isSupportDynamicLoading() throws IOException {
+        if (coreComponent) {
+            return false;
+        }
+
         URLClassLoader cl = new URLClassLoader(new URL[]{
                 new File(project.getBuild().getOutputDirectory()).toURI().toURL()
         }, getClass().getClassLoader());

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -458,16 +458,6 @@ public class RunMojo extends AbstractJettyMojo {
         
         super.configureWebApplication();
         getWebAppConfig().setWar(webAppFile.getCanonicalPath());
-        for (Artifact a : (Set<Artifact>) project.getArtifacts()) {
-            if (a.getGroupId().equals("org.jenkins-ci.main") && a.getArtifactId().equals("jenkins-core")) {
-                File coreBasedir = pluginWorkspaceMap.read(a.getId());
-                if (coreBasedir != null) {
-                    String extraCP = new File(coreBasedir, "src/main/resources").toURI() + "," + new File(coreBasedir, "target/classes").toURI();
-                    getLog().info("Will load directly from " + extraCP);
-                    getWebAppConfig().setExtraClasspath(extraCP);
-                }
-            }
-        }
         // cf. https://wiki.jenkins-ci.org/display/JENKINS/Jetty
         HashLoginService hashLoginService = (new HashLoginService("Jenkins Realm"));
         hashLoginService.setConfig(System.getProperty("jetty.home", "work") + "/etc/realm.properties");


### PR DESCRIPTION
A part of [JENKINS-41196](https://issues.jenkins-ci.org/browse/JENKINS-41196) fix that allows a plugin to be marked as core component override.