### PR TITLE
[JENKINS-45245] Remove executable-war, switching back to war-for-test

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -122,18 +122,5 @@
       </configuration>
     </component>
     
-    <!-- See JENKINS-24064 for background; used to be war-for-test classifier. -->
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>executable-war</role-hint>
-      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
-      <configuration>
-        <type>executable-war</type>
-        <extension>war</extension>
-        <language>java</language>
-        <addedToClasspath>true</addedToClasspath>
-      </configuration>
-    </component>
-
   </components>
 </component-set>


### PR DESCRIPTION
[JENKINS-45245](https://issues.jenkins-ci.org/browse/JENKINS-45245)

Specifically rolling back JENKINS-24064 changes.

cc @reviewbybees @jglick @stephenc @kohsuke @daniel-beck 