### PR TITLE
Fixing RunMojo dependency copy logic

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -202,6 +202,10 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
             if(!type.equals("jar")) {
                 return type;
             }
+            // also ignore core-assets, tests, etc.
+            if (artifact.getClassifier() != null) {
+                return type;
+            }
 
             // when a plugin depends on another plugin, it doesn't specify the type as hpi or jpi, so we need to resolve its POM to see it
             return resolvePom().getPackaging();

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.jar.JarFile;
+import org.apache.commons.lang.StringUtils;
 
 import static org.apache.maven.artifact.Artifact.*;
 
@@ -203,7 +204,7 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
                 return type;
             }
             // also ignore core-assets, tests, etc.
-            if (artifact.getClassifier() != null) {
+            if (!StringUtils.isEmpty(artifact.getClassifier())) {
                 return type;
             }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -341,10 +341,14 @@ public class RunMojo extends AbstractJettyMojo {
                     throw new UnsupportedOperationException(hpi.getFile()+" is a directory and not packaged yet. this isn't supported");
 
                 File upstreamHpl = pluginWorkspaceMap.read(hpi.getId());
+                String actualArtifactId = a.getActualArtifactId();
+                if (actualArtifactId == null) {
+                    throw new MojoExecutionException("Failed to load actual artifactId from " + a + " ~ " + a.getFile());
+                }
                 if (upstreamHpl != null) {
-                    copyHpl(upstreamHpl, pluginsDir, a.getActualArtifactId());
+                    copyHpl(upstreamHpl, pluginsDir, actualArtifactId);
                 } else {
-                    copyPlugin(hpi.getFile(), pluginsDir, a.getActualArtifactId());
+                    copyPlugin(hpi.getFile(), pluginsDir, actualArtifactId);
                 }
             }
         } catch (IOException e) {
@@ -390,8 +394,9 @@ public class RunMojo extends AbstractJettyMojo {
             getLog().warn("Moving historical " + hpi + " to *.jpi");
             hpi.renameTo(dst);
         }
-        if (versionOfPlugin(src).compareTo(versionOfPlugin(dst)) < 0) {
-            getLog().warn("will not overwrite " + dst + " with " + src + " because it is newer");
+        VersionNumber dstV = versionOfPlugin(dst);
+        if (versionOfPlugin(src).compareTo(dstV) < 0) {
+            getLog().info("will not overwrite " + dst + " with " + src + " because " + dstV + " is newer");
             return;
         }
         getLog().info("Copying dependency Jenkins plugin " + src);


### PR DESCRIPTION
Various bugs. For example, `mvn -f artifact-manager-s3 hpi:run` was producing nonsense like

```
[WARNING] will not overwrite …/artifact-manager-s3-plugin/work/plugins/null.jpi with …/.m2/repository/org/jenkins-ci/ui/handlebars/1.1.1/handlebars-1.1.1.hpi because it is newer
```

First of all, this was not a plugin dependency; there was a dependency on `handlebars-1.1.1-core-assets.jar` via `jenkins-war`, not on `handlebars-1.1.1.hpi`. (Similarly, `test`-scoped dependencies on `*-tests.jar` were messing things up.) Second, the mojo was copying into a file `null.jpi`, which wreaked havoc later.

The warning was also inappropriate even in cases where the data was correct—nothing is broken here, just a working home with some plugin updates—and failed to specify the newer version.