### PR TITLE
Use a more specific temp dir for Jetty

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
@@ -611,7 +611,7 @@ public abstract class AbstractJettyMojo extends AbstractMojo
         if (webApp.getTempDirectory() == null)
         {
             File target = new File(project.getBuild().getDirectory());
-            File tmp = new File(target,"tmp");
+            File tmp = new File(target, "jetty");
             if (!tmp.exists())
                 tmp.mkdirs();            
             webApp.setTempDirectory(tmp);


### PR DESCRIPTION
Otherwise in conjunction with https://github.com/jenkinsci/plugin-pom/pull/122 I have seen

```
[INFO] Tmp directory = …-plugin/target/tmp
[INFO] Web defaults = org/eclipse/jetty/webapp/webdefault.xml
[INFO] Web overrides =  none
[INFO] jetty-9.4.5.v20170502
[WARNING] Failed startup of context o.e.j.m.p.JettyWebAppContext@3749e682{/jenkins,null,UNAVAILABLE}{…/.m2/repository/org/jenkins-ci/main/jenkins-war/2.138.2/jenkins-war-2.138.2.war}
java.lang.IllegalStateException: Failed to delete temp dir …-plugin/target/tmp
    at org.eclipse.jetty.webapp.WebInfConfiguration.configureTempDirectory (WebInfConfiguration.java:376)
    at org.eclipse.jetty.webapp.WebInfConfiguration.resolveTempDirectory (WebInfConfiguration.java:264)
    at org.eclipse.jetty.webapp.WebInfConfiguration.preConfigure (WebInfConfiguration.java:69)
    at org.eclipse.jetty.webapp.WebAppContext.preConfigure (WebAppContext.java:506)
    at org.eclipse.jetty.webapp.WebAppContext.doStart (WebAppContext.java:544)
    at org.eclipse.jetty.maven.plugin.JettyWebAppContext.doStart (JettyWebAppContext.java:432)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:68)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:131)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:113)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:113)
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart (ContextHandlerCollection.java:167)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:68)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:131)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:113)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:113)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:68)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:131)
    at org.eclipse.jetty.server.Server.start (Server.java:452)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:105)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:113)
    at org.eclipse.jetty.server.Server.doStart (Server.java:419)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:68)
    at org.jenkinsci.maven.plugins.hpi.AbstractJettyMojo.startJetty (AbstractJettyMojo.java:530)
    at org.jenkinsci.maven.plugins.hpi.RunMojo.startJetty (RunMojo.java:702)
    at org.jenkinsci.maven.plugins.hpi.AbstractJettyMojo.execute (AbstractJettyMojo.java:345)
    at org.jenkinsci.maven.plugins.hpi.RunMojo.execute (RunMojo.java:376)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
[INFO] Started ServerConnector@4cc6f417{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
…
```

due to `target/tmp/jenkinsTests.tmp/jenkins…test/jobs/…` containing broken symlinks `lastStable`, `lastSuccessful`, and `builds/lastSuccessfulBuild`, which apparently Jetty’s `IO.delete` chokes on.