### PR TITLE
[JENKINS-20679] - Use the released version of Plugin POM 3.29 in integration tests

### DIFF
--- a/src/it/jitpack/pom.xml
+++ b/src/it/jitpack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.29-20181203.151310-8</version>
+        <version>3.29</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>

--- a/src/it/parent-3x/pom.xml
+++ b/src/it/parent-3x/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.29-20181203.151310-8</version>
+        <version>3.29</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>

--- a/src/it/process-jar/pom.xml
+++ b/src/it/process-jar/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29-20181203.151310-8</version>
+    <version>3.29</version>
   </parent>
 
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>

--- a/src/it/snapshot-version-override/pom.xml
+++ b/src/it/snapshot-version-override/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29-20181203.151310-8</version>
+    <version>3.29</version>
   </parent>
 
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>

--- a/src/it/verify-it/pom.xml
+++ b/src/it/verify-it/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29-20181203.151310-8</version>
+    <version>3.29</version>
   </parent>
 
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>


### PR DESCRIPTION
Follow-up to #75 after the release

@jenkinsci/java11-support 
