### PR TITLE
Pass minimumJavaVersion to RunMojo so that hpi:run works again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,6 @@
                 </goals>
                 <configuration>
                   <streamLogs>false</streamLogs>
-                  <debug>true</debug>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,9 @@
                 </goals>
                 <configuration>
                   <streamLogs>false</streamLogs>
+                  <environmentVariables>
+                      <JENKINS_HOME/> <!-- block anything set by a CI environment -->
+                  </environmentVariables>
                 </configuration>
               </execution>
             </executions>

--- a/src/it/parent-3x/invoker.properties
+++ b/src/it/parent-3x/invoker.properties
@@ -1,3 +1,3 @@
 # install, not verify, because we want to check the artifact as we would be about to deploy it
 # release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install
+invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install hpi:run

--- a/src/it/parent-3x/src/main/java/test/JustTesting.java
+++ b/src/it/parent-3x/src/main/java/test/JustTesting.java
@@ -1,0 +1,24 @@
+package test;
+
+import hudson.Main;
+import hudson.init.Initializer;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
+import jenkins.util.Timer;
+
+public class JustTesting {
+
+    private JustTesting() {}
+
+    @Initializer
+    public static void shutDown() {
+        if (Main.isUnitTest) {
+            return;
+        }
+        Timer.get().schedule(() -> {
+            Jenkins.getInstance().doSafeExit(null);
+            return null;
+        }, 15, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/it/parent-3x/verify.groovy
+++ b/src/it/parent-3x/verify.groovy
@@ -56,6 +56,8 @@ checkArtifact(installed, 'parent-3x-1.0-SNAPSHOT-test-sources.jar',
 // (tricky since this script is called only once mvn is done)
 def text = new File(basedir, 'build.log').text
 assert text.contains('INFO: Jenkins is fully up and running') && text.contains('INFO: Jenkins stopped')
+assert new File(basedir, 'work/plugins/parent-3x.hpl').file
+assert new File(basedir, 'work/plugins/structs.jpi').file
 
 // TODO run a copy of jenkins.war with the installed *.hpi predeployed and do a similar check
 

--- a/src/it/parent-3x/verify.groovy
+++ b/src/it/parent-3x/verify.groovy
@@ -52,7 +52,10 @@ checkArtifact(installed, 'parent-3x-1.0-SNAPSHOT-test-sources.jar',
     ['InjectedTest.java'],
     [:])
 
-// TODO try mvn hpi:run (how do we find the right version of mvn to run?) and check that we can access http://localhost:8080/jenkins/sample/
+// TODO check that we can access http://localhost:8080/jenkins/sample/ during hpi:run
+// (tricky since this script is called only once mvn is done)
+def text = new File(basedir, 'build.log').text
+assert text.contains('INFO: Jenkins is fully up and running') && text.contains('INFO: Jenkins stopped')
 
 // TODO run a copy of jenkins.war with the installed *.hpi predeployed and do a similar check
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -70,7 +70,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
      * Specify the minimum version of Java that this plugin requires.
      */
     @Parameter(required = true)
-    private String minimumJavaVersion;
+    protected String minimumJavaVersion;
 
     /**
      * Generates a manifest file to be included in the .hpi file

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -260,10 +260,11 @@ public class RunMojo extends AbstractJettyMojo {
             if (h == null) {
                 h = System.getenv("HUDSON_HOME");
             }
-            if(h!=null)
+            if (h != null && !h.isEmpty() && /* see pom.xml override */!h.equals("null")) {
                 jenkinsHome = new File(h);
-            else
+            } else {
                 jenkinsHome = new File(basedir, "work");
+            }
         }
 
         // auto-enable stapler trace, unless otherwise configured already.

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -214,6 +214,12 @@ public class RunMojo extends AbstractJettyMojo {
     private Collection<Logger> loggerReferences; // just to prevent GC
 
     /**
+     * Specify the minimum version of Java that this plugin requires.
+     */
+    @Parameter(required = true)
+    private String minimumJavaVersion;
+
+    /**
      * The context path for the webapp. Defaults to the
      * name of the webapp's artifact.
      *
@@ -465,6 +471,7 @@ public class RunMojo extends AbstractJettyMojo {
         hpl.pluginFirstClassLoader = this.pluginFirstClassLoader;
         hpl.maskClasses = this.maskClasses;
         hpl.remoteRepos = this.remoteRepos;
+        hpl.minimumJavaVersion = this.minimumJavaVersion;
         /* As needed:
         hpl.artifactFactory = this.artifactFactory;
         hpl.artifactResolver = this.artifactResolver;


### PR DESCRIPTION
Corrects a regression in #75, noticed in https://github.com/jenkinsci/external-monitor-job-plugin/pull/18.