### PR TITLE
Permitting ${hpi.compatibleSinceVersion} to be used to configure mojos rather than a <plugin> section

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -57,7 +57,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
      * Optional - the oldest version of this plugin which the current version is
      * configuration-compatible with.
      */
-    @Parameter
+    @Parameter(property = "hpi.compatibleSinceVersion")
     private String compatibleSinceVersion;
 
     /**


### PR DESCRIPTION
To simplify plugin POMs, especially after https://github.com/jenkinsci/plugin-pom/pull/134 (no need for a `plugin-pom` patch).