### PR TITLE
[WIP] [JENKINS-28942] Add property to instruct the Core to not add implied dependencies

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -73,6 +73,15 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     protected String minimumJavaVersion;
 
     /**
+     * Indicates the plugin should not get any implied dependency until the specified (Jenkins core) version included.
+     * <p>Example: if a plugin specifies this with a value of <em>2.60.3</em>, and used bouncycastle API (which got detacted in 2.16) without explictly
+     * declaring the dependency against bouncycastle-api, then the plugin would likely fail at runtime because Jenkins Core Plugin Management will
+     * then <strong>not</strong> add bouncycastle-api as an implicit dependency.</p>
+     */
+    @Parameter(property = "hpi.noDetachedPluginUntil", required = true)
+    protected String noDetachedPluginUntil;
+
+    /**
      * Generates a manifest file to be included in the .hpi file
      */
     protected void generateManifest(MavenArchiveConfiguration archive, File manifestFile) throws MojoExecutionException {
@@ -116,6 +125,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
         mainSection.addAttributeAndCheck(new Manifest.Attribute("Group-Id",project.getGroupId()));
         mainSection.addAttributeAndCheck(new Manifest.Attribute("Short-Name",project.getArtifactId()));
         mainSection.addAttributeAndCheck(new Manifest.Attribute("Long-Name",pluginName));
+        mainSection.addAttributeAndCheck(new Manifest.Attribute("No-Detached-Plugin-Until", noDetachedPluginUntil));
         String url = project.getUrl();
         if(url!=null)
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Url", url));


### PR DESCRIPTION
[JENKINS-28942](https://issues.jenkins-ci.org/browse/JENKINS-28942)

* [x] Code adding the property, also to gather agreement on the naming **`noDetachedPluginUntil`**
* [ ] add Maven invoker IT for the new property

After this, there will need also:
* a change against the update-center generation repo so the property is extracted and added to JSON (https://github.com/jenkins-infra/update-center2/)
* a change in Jenkins Core to use that property to filter the implied dependencies depending on the property value (see https://github.com/jenkinsci/jenkins/blob/226f7b4c2bedb14b70f12da90db15574e18364d0/core/src/main/resources/jenkins/split-plugins.txt#L9-L30)

cc @jenkinsci/java11-support ([given I am doing this because this is the right way to handle my main concern about JAXB addition as a detached plugin](https://issues.jenkins-ci.org/browse/JENKINS-55681): that doing so nobody will ever have an actual way to break the dependency against JAXB)

@daniel-beck @jglick who commented on the JIRA.

**While this is still WIP for missing tests, please validate the `noDetachedPluginUntil` name of the attribute so that I have no back and forths to do when doing the associated PR in others repos.**