### PR TITLE
A ProjectBuildingException on some dependency should not be fatal

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -494,7 +494,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         // List up IDs of Jenkins plugin dependencies
         Set<String> jenkinsPlugins = new HashSet<String>();
         for (MavenArtifact artifact : artifacts) {
-            if(artifact.isPlugin())
+            if (artifact.isPluginBestEffort(getLog()))
                 jenkinsPlugins.add(artifact.getId());
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
@@ -125,7 +125,7 @@ public class HplMojo extends AbstractJenkinsManifestMojo {
         // List up IDs of Jenkins plugin dependencies
         Set<String> jenkinsPlugins = new HashSet<String>();
         for (MavenArtifact artifact : artifacts) {
-            if(artifact.isPlugin())
+            if (artifact.isPluginBestEffort(getLog()))
                 jenkinsPlugins.add(artifact.getId());
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -30,7 +30,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             Writer w = new OutputStreamWriter(new FileOutputStream(new File(testDir,"index")),"UTF-8");
 
             for (MavenArtifact a : getProjectArtfacts()) {
-                if(!a.isPlugin())
+                if (!a.isPluginBestEffort(getLog()))
                     continue;
 
                 String artifactId = a.getActualArtifactId();


### PR DESCRIPTION
E.g. https://github.com/kubernetes-client/java/pull/334#issuecomment-475674883. Maven already prints a warning about such dependencies when computing the set of artifacts, as does the Enforcer plugin, so this is just preventing later phases from breaking the build.