### PR TITLE
Align versions of Maven and Maven Plugin Tools dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
     <java.level>8</java.level>
     <!-- TODO: remove after updating to a recent parent POM -->
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven.version>2.2.0</maven.version>
+    <maven-plugin-tools.version>3.5</maven-plugin-tools.version>
   </properties>
 
   <repositories>
@@ -74,7 +76,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.5</version>
+      <version>${maven-plugin-tools.version}</version>
       <!-- annotations are not needed for plugin execution, so exclude using provided scope -->
       <scope>provided</scope>
     </dependency>
@@ -103,12 +105,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.2.0</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>2.2.0</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -118,7 +120,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.2.0</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -217,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
+        <version>${maven-plugin-tools.version}</version>
         <configuration>
           <goalPrefix>hpi</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -324,7 +326,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
+        <version>${maven-plugin-tools.version}</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
I would like to update to Maven 3.5 later to keep it aligned with Plugin POM, but such change should at least help with dependency management a bit