### PR TITLE
[JENKINS-58771] Consider plugin dependencies with test scope to consider whether bundling a dependency is needed

### DIFF
--- a/src/it/JENKINS-58771-packaged-plugins/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins/invoker.properties
@@ -1,3 +1,1 @@
-# install, not verify, because we want to check the artifact as we would be about to deploy it
-# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install
+invoker.goals=clean install

--- a/src/it/JENKINS-58771-packaged-plugins/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins/invoker.properties
@@ -1,0 +1,3 @@
+# install, not verify, because we want to check the artifact as we would be about to deploy it
+# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
+invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install

--- a/src/it/JENKINS-58771-packaged-plugins/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins/pom.xml
@@ -29,13 +29,6 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    
-    <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>HEAD</tag>
-    </scm>
 
     <dependencies>
         <dependency>

--- a/src/it/JENKINS-58771-packaged-plugins/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.47</version>
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>JENKINS-58771-packaged-plugins</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <java.level>8</java.level>
+        <jenkins.version>2.176.1</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>3.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-extensions</artifactId>
+            <version>1.3.7</version>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.176.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/JENKINS-58771-packaged-plugins/src/main/resources/index.jelly
+++ b/src/it/JENKINS-58771-packaged-plugins/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-58771-packaged-plugins/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins/verify.groovy
@@ -1,4 +1,4 @@
-assert ! new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/joda-time-2.9.5.jar').exists()
-assert ! new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/multiline-secrets-ui-1.0.jar').exists()
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib').listFiles().length == 1
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/JENKINS-58771-packaged-plugins.jar').exists()
 
 return true

--- a/src/it/JENKINS-58771-packaged-plugins/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins/verify.groovy
@@ -1,0 +1,4 @@
+assert ! new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/joda-time-2.9.5.jar').exists()
+assert ! new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/multiline-secrets-ui-1.0.jar').exists()
+
+return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -16,6 +16,7 @@ package org.jenkinsci.maven.plugins.hpi;
  * limitations under the License.
  */
 
+import com.google.common.collect.Sets;
 import hudson.Extension;
 import java.io.BufferedReader;
 import java.io.File;
@@ -487,13 +488,16 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
 
         Set<MavenArtifact> artifacts = getProjectArtfacts();
 
+        // Also capture test dependencies
+        Set<MavenArtifact> dependencyArtifacts = getDirectDependencyArtfacts();
+
         List<String> duplicates = findDuplicates(artifacts);
 
         List<File> dependentWarDirectories = new ArrayList<File>();
 
         // List up IDs of Jenkins plugin dependencies
         Set<String> jenkinsPlugins = new HashSet<String>();
-        for (MavenArtifact artifact : artifacts) {
+        for (MavenArtifact artifact : Sets.union(artifacts, dependencyArtifacts)) {
             if (artifact.isPluginBestEffort(getLog()))
                 jenkinsPlugins.add(artifact.getId());
         }


### PR DESCRIPTION
[JENKINS-58771](https://issues.jenkins-ci.org/browse/JENKINS-58771)

Plugin artifacts are determined only from project artifacts, which captures only dependencies with compile/runtime scopes.

In some cases, it can happen that transitive dependencies are resolved via a test-scoped trail, causing unexpected dependencies to be packaged in the resulting hpi.