### PR TITLE
CI improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,10 @@
 properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
-
-timeout(time: 1, unit: 'HOURS') {
-  node('docker') {
+node('maven') {
     checkout scm
-    docker.image('maven:3.5.3-jdk-8').inside {
-      try {
-        sh 'mvn -B -Prun-its clean install site'
-      } catch (e) {
-        // Too big (~25Mb) to archive for successful builds:
-        archiveArtifacts artifacts: 'target/its/*/build.log', allowEmptyArchive: true
-        throw e
-      }
+    timeout(time: 1, unit: 'HOURS') {
+        // TODO Azure mirror
+        withEnv(['MAVEN_OPTS=-Djansi.force=true']) {
+            sh 'mvn -B -Dstyle.color=always -ntp -Prun-its clean install site'
+        }
     }
-  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,10 @@ node('maven') {
     checkout scm
     timeout(time: 1, unit: 'HOURS') {
         // TODO Azure mirror
-        withEnv(['MAVEN_OPTS=-Djansi.force=true']) {
-            sh 'mvn -B -Dstyle.color=always -ntp -Prun-its clean install site'
+        ansiColor('xterm') {
+            withEnv(['MAVEN_OPTS=-Djansi.force=true']) {
+                sh 'mvn -B -Dstyle.color=always -ntp -Prun-its clean install site'
+            }
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <streamLogs>false</streamLogs>
+                  <streamLogs>true</streamLogs>
                   <environmentVariables>
                       <JENKINS_HOME /> <!-- block anything set by a CI environment -->
                   </environmentVariables>

--- a/src/it/JENKINS-45740-metadata/invoker.properties
+++ b/src/it/JENKINS-45740-metadata/invoker.properties
@@ -1,3 +1,3 @@
 # install, not verify, because we want to check the artifact as we would be about to deploy it
 # release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install
+invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean install

--- a/src/it/JENKINS-58771-packaged-plugins/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean install
+invoker.goals=-Dstyle.color=always -ntp clean install

--- a/src/it/assemble-dependencies-as-jpi/invoker.properties
+++ b/src/it/assemble-dependencies-as-jpi/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean generate-resources
+invoker.goals=-Dstyle.color=always -ntp clean generate-resources

--- a/src/it/assemble-dependencies/invoker.properties
+++ b/src/it/assemble-dependencies/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean generate-resources
+invoker.goals=-Dstyle.color=always -ntp clean generate-resources

--- a/src/it/bad-bundle/invoker.properties
+++ b/src/it/bad-bundle/invoker.properties
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-invoker.goals=clean generate-resources
+invoker.goals=-Dstyle.color=always -ntp clean generate-resources
 invoker.buildResult = failure

--- a/src/it/bundle-fails-optional-conflict/invoker.properties
+++ b/src/it/bundle-fails-optional-conflict/invoker.properties
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-invoker.goals=clean generate-resources
+invoker.goals=-Dstyle.color=always -ntp clean generate-resources
 invoker.buildResult = failure

--- a/src/it/bundle-with-optional-deps/invoker.properties
+++ b/src/it/bundle-with-optional-deps/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean generate-resources
+invoker.goals=-Dstyle.color=always -ntp clean generate-resources

--- a/src/it/compile-fork-it/invoker.properties
+++ b/src/it/compile-fork-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean compile
+invoker.goals=-Dstyle.color=always -ntp clean compile

--- a/src/it/compile-it/invoker.properties
+++ b/src/it/compile-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean compile
+invoker.goals=-Dstyle.color=always -ntp clean compile

--- a/src/it/parent-3x/invoker.properties
+++ b/src/it/parent-3x/invoker.properties
@@ -1,3 +1,3 @@
 # install, not verify, because we want to check the artifact as we would be about to deploy it
 # release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Pjenkins-release -Drelease.skipTests=false clean install hpi:run
+invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean install hpi:run

--- a/src/it/process-jar/invoker.properties
+++ b/src/it/process-jar/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean verify
+invoker.goals=-Dstyle.color=always -ntp clean verify

--- a/src/it/snapshot-version-override/invoker.properties
+++ b/src/it/snapshot-version-override/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean verify
+invoker.goals=-Dstyle.color=always -ntp clean verify

--- a/src/it/verify-it/invoker.properties
+++ b/src/it/verify-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=clean verify
+invoker.goals=-Dstyle.color=always -ntp clean verify


### PR DESCRIPTION
Found it cumbersome to track down the error in #150 so wanted to modernize a bit. With `-ntp` it is reasonable to stream IT logs to the main build log.

![ci](https://user-images.githubusercontent.com/154109/68042504-70950e00-fca9-11e9-9e25-320214d4c179.png)
