### PR TITLE
Upgrade Jetty from 9.4.5.v20170502 to 9.4.22.v20191022

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-maven-plugin</artifactId>
-      <version>9.4.5.v20170502</version>
+      <version>9.4.22.v20191022</version>
     </dependency>
     <dependency>
       <groupId>net.java.sezpoz</groupId>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.project.MavenProjectBuilder;
 import org.eclipse.jetty.maven.plugin.JettyWebAppContext;
 import org.eclipse.jetty.maven.plugin.MavenServerConnector;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -503,9 +504,8 @@ public class RunMojo extends AbstractJettyMojo {
                 }
             }
         }
-        // cf. https://wiki.jenkins-ci.org/display/JENKINS/Jetty
         HashLoginService hashLoginService = (new HashLoginService("Jenkins Realm"));
-        hashLoginService.setConfig(System.getProperty("jetty.home", "work") + "/etc/realm.properties");
+        hashLoginService.setUserStore(new UserStore());
         getWebAppConfig().getSecurityHandler().setLoginService(hashLoginService);
     }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.util.Scanner;
+import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -504,8 +505,12 @@ public class RunMojo extends AbstractJettyMojo {
                 }
             }
         }
-        HashLoginService hashLoginService = (new HashLoginService("Jenkins Realm"));
-        hashLoginService.setUserStore(new UserStore());
+        HashLoginService hashLoginService = (new HashLoginService("default"));
+        UserStore userStore = new UserStore();
+        hashLoginService.setUserStore(userStore);
+        userStore.addUser("alice", new Password("alice"), new String[] {"user", "female"});
+        userStore.addUser("bob", new Password("bob"), new String[] {"user", "male"});
+        userStore.addUser("charlie", new Password("charlie"), new String[] {"user", "male"});
         getWebAppConfig().getSecurityHandler().setLoginService(hashLoginService);
     }
 


### PR DESCRIPTION
Supersedes #150. Picking up the sort of no-op servlet security realm that `JenkinsRule` uses. Confirmed that this works with the `build-token-root` plugin with authentication enabled (`initialAdminPassword` style).