### PR TITLE
Improve debugging formatting

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
@@ -618,9 +618,9 @@ public abstract class AbstractJettyMojo extends AbstractMojo
         }
 
         getLog().info("Context path = " + webApp.getContextPath());
-        getLog().info("Tmp directory = "+ (webApp.getTempDirectory()== null? " determined at runtime": webApp.getTempDirectory()));
-        getLog().info("Web defaults = "+(webApp.getDefaultsDescriptor()==null?" jetty default":webApp.getDefaultsDescriptor()));
-        getLog().info("Web overrides = "+(webApp.getOverrideDescriptor()==null?" none":webApp.getOverrideDescriptor()));
+        getLog().info("Tmp directory = " + (webApp.getTempDirectory()== null ? "(determined at runtime)" : webApp.getTempDirectory()));
+        getLog().info("Web defaults = " + (webApp.getDefaultsDescriptor()== null ? "(jetty default)" : webApp.getDefaultsDescriptor()));
+        getLog().info("Web overrides = " + (webApp.getOverrideDescriptor()== null ? "(none)" : webApp.getOverrideDescriptor()));
     }
 
 


### PR DESCRIPTION
When I use `hpi:run` in a project, I see something like this:
```
[INFO] Tmp directory = /tmp/jenkinsci/workflow-basic-steps-plugin/target/jetty
[INFO] Web defaults = org/eclipse/jetty/webapp/webdefault.xml
[INFO] Web overrides =  none
```
There are two spaces between `=` and `none` for no apparent reason.

This change replaces the second space followed by a _default_message_ with `(`+_default_message_+`)`.