### PR TITLE
[JENKINS-58771] Avoid more cases of bundling libs incorrectly

### DIFF
--- a/src/it/JENKINS-58771-packaged-plugins-2/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins-2/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-Dstyle.color=always -ntp clean install

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.57</version>
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>JENKINS-58771-packaged-plugins</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <java.level>8</java.level>
+        <jenkins.version>2.176.1</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.80</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>3.3</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.176.x</artifactId>
+                <version>5</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -34,12 +34,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.80</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.3</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -30,16 +30,31 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <!--
+    workflow-support pulls jboss-marshalling-river through 2 different trails
+    * through workflow-cps in compile scope
+    * directly in test scope
+    -->
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+<!--            +- org.jenkins-ci.plugins.workflow:workflow-cps:jar:2.76:compile-->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.22:compile-->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-api:jar:2.37:compile-->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-support:jar:3.3:compile-->
+<!--            |  |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:compile-->
+<!--            |  |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:compile-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
+<!--            +- org.jenkins-ci.plugins.workflow:workflow-support:jar:tests:3.3:test-->
+<!--            |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:compile-->
+<!--            |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:compile-->
         </dependency>
     </dependencies>
 

--- a/src/it/JENKINS-58771-packaged-plugins-2/src/main/resources/index.jelly
+++ b/src/it/JENKINS-58771-packaged-plugins-2/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-58771-packaged-plugins-2/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins-2/verify.groovy
@@ -1,3 +1,4 @@
+assert !new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/jboss-marshalling-river-2.0.6.Final.jar').exists()
 assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib').listFiles().length == 1
 assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/JENKINS-58771-packaged-plugins.jar').exists()
 

--- a/src/it/JENKINS-58771-packaged-plugins-2/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins-2/verify.groovy
@@ -1,0 +1,4 @@
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib').listFiles().length == 1
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/JENKINS-58771-packaged-plugins.jar').exists()
+
+return true

--- a/src/it/JENKINS-58771-packaged-plugins-3/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins-3/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-Dstyle.color=always -ntp clean install

--- a/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
@@ -30,6 +30,13 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <!--
+    parent POM pulls com.github.spotbugs:spotbugs-annotations with provided scope. It pulls
+    com.google.code.findbugs:jsr305:jar:3.0.2 transitively.
+
+    google-oauth-plugin pulls com.google.code.findbugs:jsr305:jar:3.0.2 transitively. Resulting scope is compile, but as
+    the trail through spotbugs-annotations is shorter, it ends up packaged instead of excluded as coming from a plugin.
+    -->
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.57</version>
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>JENKINS-58771-packaged-plugins</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <java.level>8</java.level>
+        <jenkins.version>2.176.1</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>google-oauth-plugin</artifactId>
+            <version>0.8</version>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.176.x</artifactId>
+                <version>5</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/JENKINS-58771-packaged-plugins-3/src/main/resources/index.jelly
+++ b/src/it/JENKINS-58771-packaged-plugins-3/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-58771-packaged-plugins-3/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins-3/verify.groovy
@@ -1,3 +1,4 @@
+assert !new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/jsr305-3.0.2.jar').exists()
 assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib').listFiles().length == 1
 assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/JENKINS-58771-packaged-plugins.jar').exists()
 

--- a/src/it/JENKINS-58771-packaged-plugins-3/verify.groovy
+++ b/src/it/JENKINS-58771-packaged-plugins-3/verify.groovy
@@ -1,0 +1,4 @@
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib').listFiles().length == 1
+assert new File(basedir, 'target/JENKINS-58771-packaged-plugins/WEB-INF/lib/JENKINS-58771-packaged-plugins.jar').exists()
+
+return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -496,23 +496,27 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         List<File> dependentWarDirectories = new ArrayList<File>();
 
         // List up IDs of Jenkins plugin dependencies
-        Set<String> jenkinsPlugins = new HashSet<String>();
+        Set<String> jenkinsPlugins = new HashSet<>();
+        Set<String> excludedArtifacts = new HashSet<>();
         for (MavenArtifact artifact : Sets.union(artifacts, dependencyArtifacts)) {
             if (artifact.isPluginBestEffort(getLog()))
                 jenkinsPlugins.add(artifact.getId());
             // Exclude dependency if it comes from test or provided trail.
             // Most likely a plugin transitive dependency but the trail through (test,provided) dep is shorter
             if (artifact.hasScope("test", "provided"))
-                jenkinsPlugins.add(artifact.getId());
+                excludedArtifacts.add(artifact.getId());
         }
 
         OUTER:
         for (MavenArtifact artifact : artifacts) {
-            if(jenkinsPlugins.contains(artifact.getId()))
+            if (jenkinsPlugins.contains(artifact.getId()))
                 continue;   // plugin dependency need not be WEB-INF/lib
-            if(artifact.getDependencyTrail().size() >= 1 && jenkinsPlugins.contains(artifact.getDependencyTrail().get(1)))
-                continue;   // no need to have transitive dependencies through plugins in WEB-INF/lib.
-
+            if (artifact.getDependencyTrail().size() >= 1) {
+                if (jenkinsPlugins.contains(artifact.getDependencyTrail().get(1)))
+                    continue; // no need to have transitive dependencies through plugins in WEB-INF/lib.
+                if (excludedArtifacts.contains(artifact.getDependencyTrail().get(1)))
+                    continue; // exclude artifacts resolved through a test or provided scope
+            }
             // if the dependency goes through jenkins core, we don't need to bundle it in the war
             // because jenkins-core comes in the <provided> scope, I think this is a bug in Maven that it puts such
             // dependencies into the artifact list.

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -503,19 +503,23 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
                 jenkinsPlugins.add(artifact.getId());
             // Exclude dependency if it comes from test or provided trail.
             // Most likely a plugin transitive dependency but the trail through (test,provided) dep is shorter
-            if (artifact.hasScope("test", "provided"))
+            if (artifact.hasScope("test", "provided")) {
                 excludedArtifacts.add(artifact.getId());
+            }
         }
 
         OUTER:
         for (MavenArtifact artifact : artifacts) {
-            if (jenkinsPlugins.contains(artifact.getId()))
+            if (jenkinsPlugins.contains(artifact.getId())) {
                 continue;   // plugin dependency need not be WEB-INF/lib
+            }
             if (artifact.getDependencyTrail().size() >= 1) {
-                if (jenkinsPlugins.contains(artifact.getDependencyTrail().get(1)))
+                if (jenkinsPlugins.contains(artifact.getDependencyTrail().get(1))) {
                     continue; // no need to have transitive dependencies through plugins in WEB-INF/lib.
-                if (excludedArtifacts.contains(artifact.getDependencyTrail().get(1)))
+                }
+                if (excludedArtifacts.contains(artifact.getDependencyTrail().get(1))) {
                     continue; // exclude artifacts resolved through a test or provided scope
+                }
             }
             // if the dependency goes through jenkins core, we don't need to bundle it in the war
             // because jenkins-core comes in the <provided> scope, I think this is a bug in Maven that it puts such

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -500,6 +500,10 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         for (MavenArtifact artifact : Sets.union(artifacts, dependencyArtifacts)) {
             if (artifact.isPluginBestEffort(getLog()))
                 jenkinsPlugins.add(artifact.getId());
+            // Exclude dependency if it comes from test or provided trail.
+            // Most likely a plugin transitive dependency but the trail through (test,provided) dep is shorter
+            if (artifact.hasScope("test", "provided"))
+                jenkinsPlugins.add(artifact.getId());
         }
 
         OUTER:


### PR DESCRIPTION
Expands https://github.com/jenkinsci/maven-hpi-plugin/pull/140

Sometimes some dependencies gets pulled through test or provided scope
trails, because in fact they are being pulled in compile scope through a plugin with a longer trail.

Inspired by https://github.com/jenkinsci/kubernetes-plugin/pull/729