### PR TITLE
Use SupportLogFormatter from hpi:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
       <artifactId>version-number</artifactId>
       <version>1.7</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.lib</groupId>
+      <artifactId>support-log-formatter</artifactId>
+      <version>1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/parent-3x/verify.groovy
+++ b/src/it/parent-3x/verify.groovy
@@ -55,7 +55,7 @@ checkArtifact(installed, 'parent-3x-1.0-SNAPSHOT-test-sources.jar',
 // TODO check that we can access http://localhost:8080/jenkins/sample/ during hpi:run
 // (tricky since this script is called only once mvn is done)
 def text = new File(basedir, 'build.log').text
-assert text.contains('INFO: Jenkins is fully up and running') && text.contains('INFO: Jenkins stopped')
+assert text.contains('Jenkins is fully up and running') && text.contains('INFO\tjenkins.model.Jenkins#cleanUp: Jenkins stopped')
 assert new File(basedir, 'work/plugins/parent-3x.hpl').file
 assert new File(basedir, 'work/plugins/structs.jpi').file
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -15,6 +15,7 @@
 package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
+import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
@@ -376,6 +377,11 @@ public class RunMojo extends AbstractJettyMojo {
             throw new MojoExecutionException("Unable to copy dependency plugin",e);
         } catch (ArtifactResolutionException e) {
             throw new MojoExecutionException("Unable to copy dependency plugin",e);
+        }
+
+        if (System.getProperty("java.util.logging.config.file") == null) {
+            // see org.apache.juli.logging.DirectJDKLog
+            System.setProperty("org.apache.juli.formatter", SupportLogFormatter.class.getName());
         }
 
         if (loggers != null) {


### PR DESCRIPTION
Analogue of https://github.com/jenkinsci/winstone/pull/63. Before:

```
Apr 21, 2020 4:01:24 PM hudson.WebAppMain$3 run
INFO: Jenkins is fully up and running
```

After:

```
2020-04-21 20:35:45.911+0000 [id=73]	INFO	hudson.WebAppMain$3#run: Jenkins is fully up and running
```