### PR TITLE
Offer a browse URL from hpi:run including the likes of nip.io if desired

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -162,6 +162,14 @@ public class RunMojo extends AbstractJettyMojo {
     protected String defaultHost;
 
     /**
+     * Optional wildcard DNS domain to help set a distinct Jenkins root URL from every plugin.
+     * Just prints a URL you ought to set.
+     * Recommended: {@code nip.io}
+     */
+    @Parameter(property = "wildcardDNS")
+    protected String wildcardDNS;
+
+    /**
      * If true, the context will be restarted after a line feed on
      * the input console. Disabled by default.
      */
@@ -744,6 +752,14 @@ public class RunMojo extends AbstractJettyMojo {
             if (StringUtils.isNotEmpty(defaultHost)) {
                 httpConnector.setHost(defaultHost);
             }
+            String browserHost;
+            if (wildcardDNS != null && "localhost".equals(defaultHost)) {
+                browserHost = getProject().getArtifactId() + ".127.0.0.1." + wildcardDNS;
+            } else {
+                getLog().info("Try setting -DwildcardDNS=nip.io in a profile");
+                browserHost = httpConnector.getHost();
+            }
+            getLog().info("===========> Browse to: http://" + browserHost + ":" + (defaultPort != 0 ? defaultPort : MavenServerConnector.DEFAULT_PORT) + webApp.getContextPath() + "/");
         }
         super.startJetty();
     }


### PR DESCRIPTION
When you `hpi:run` from a lot of plugins, each with their own `work` directory, it is annoying to always be using the same `http://localhost:8080/jenkins/` URL: your address bar will get all mixed up, cookies will get crossed over, saved `initialAdminPassword`s will be confused, etc. It is nicer to browse to e.g. `http://build-token-root.127.0.0.1.nip.io:8080/jenkins/` which corresponds to just one `work` directory. This patch just makes it a bit easier to get such a URL.