### PR TITLE
Fix `list-plugin-dependencies` documentation, not all plugins are listed by the mojo

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ListPluginDependenciesMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ListPluginDependenciesMojo.java
@@ -14,7 +14,8 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 /**
- * List up all the plugin dependencies.
+ * List up all plugin dependencies declared in the project.
+ * Transitive plugin dependencies will not be listed.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -26,6 +27,9 @@ public class ListPluginDependenciesMojo extends AbstractHpiMojo {
     @Parameter(property = "outputFile")
     protected File outputFile;
 
+    // TODO(oleg_nenashev): Add support for transitive plugin dependencies.
+    // Might require reusing/refactoring the plugin dependency tree resolution code in plugin installation mojos.
+    
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             Writer w = outputFile==null ? new NullWriter() : new OutputStreamWriter(new FileOutputStream(outputFile),"UTF-8");


### PR DESCRIPTION
Just noticed a documentation bug while answering a question from @rsvoboda in https://github.com/jenkinsci/jenkinsfile-runner/pull/388#issuecomment-706065413 . Documentation on https://jenkinsci.github.io/maven-hpi-plugin/list-plugin-dependencies-mojo.html is misleading.

Also added a TODO comment to actually add support for listing all plugin dependencies without actual download in https://jenkinsci.github.io/maven-hpi-plugin/assemble-dependencies-mojo.html

