### PR TITLE
`validate-hpi` needs test-scope dependency resolution for these plugin dependencies using test scope

### DIFF
--- a/src/it/check-core-version-failure/pom.xml
+++ b/src/it/check-core-version-failure/pom.xml
@@ -21,6 +21,12 @@
       <artifactId>jackson2-api</artifactId>
       <version>2.11.2</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.36</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
@@ -15,7 +15,7 @@ import java.util.jar.JarFile;
 /**
  * Validates dependencies depend on older or equal core than the current plugin.
  */
-@Mojo(name = "validate-hpi", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "validate-hpi", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.TEST)
 public class ValidateHpiMojo extends AbstractHpiMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {


### PR DESCRIPTION
Follow-up of #191 