### PR TITLE
[JENKINS-64408] support targetPath property for webResources

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -129,7 +129,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
      * The directory where the webapp is built.
      */
     @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}")
-    private File webappDirectory;
+    protected File webappDirectory;
 
     /**
      * Single directory for extra files to include in the WAR.
@@ -407,13 +407,17 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
             if (webappDirectory.exists()) {
                 String[] fileNames = getWarFiles(resource);
                 for (String fileName : fileNames) {
+                    File targetDirectory = webappDirectory;
+                    if (StringUtils.isNotBlank(resource.getTargetPath())) {
+                        targetDirectory = new File(webappDirectory, resource.getTargetPath());
+                    }
                     if (resource.isFiltering()) {
                         copyFilteredFile(new File(resource.getDirectory(), fileName),
-                            new File(webappDirectory, fileName), null, getFilterWrappers(),
+                            new File(targetDirectory, fileName), null, getFilterWrappers(),
                             filterProperties);
                     } else {
                         copyFileIfModified(new File(resource.getDirectory(), fileName),
-                            new File(webappDirectory, fileName));
+                            new File(targetDirectory, fileName));
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
@@ -2,7 +2,6 @@ package org.jenkinsci.maven.plugins.hpi;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -98,7 +97,12 @@ public class HplMojo extends AbstractJenkinsManifestMojo {
             mainSection.addAttributeAndCheck(new Attribute("Libraries", StringUtils.join(paths, ",")));
 
             // compute Resource-Path entry
-            mainSection.addAttributeAndCheck(new Attribute("Resource-Path",warSourceDirectory.getAbsolutePath()));
+            if (webappDirectory != null && webappDirectory.isDirectory()) {
+                mainSection.addAttributeAndCheck(new Attribute("Resource-Path",webappDirectory.getAbsolutePath()));
+            } else {
+                getLog().info("webappDirectory does not exist, will use warSourceDirectory");
+                mainSection.addAttributeAndCheck(new Attribute("Resource-Path",warSourceDirectory.getAbsolutePath()));
+            }
 
             printWriter = new PrintWriter(new FileWriter(hplFile));
             mf.write(printWriter);

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -126,6 +126,12 @@ public class RunMojo extends AbstractJettyMojo {
     protected String dependencyResolution;
 
     /**
+     * The directory where the webapp is built.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}")
+    private File webappDirectory;
+
+    /**
      * Single directory for extra files to include in the WAR.
      */
     @Parameter(defaultValue = "${basedir}/src/main/webapp")
@@ -491,6 +497,7 @@ public class RunMojo extends AbstractJettyMojo {
         hpl.setJenkinsHome(jenkinsHome);
         hpl.setLog(getLog());
         hpl.pluginName = getProject().getName();
+        hpl.webappDirectory = webappDirectory;
         hpl.warSourceDirectory = warSourceDirectory;
         hpl.scopeFilter = new ScopeArtifactFilter("runtime");
         hpl.projectBuilder = this.projectBuilder;


### PR DESCRIPTION
- it works for the packaging phase out of the box
- for use as part of `hpi:run`, the goals `compile` and `hpi:hpi` must be executed before to ensure that `webappDirectory` exists. otherwise `warSourceDirectory` will be used as before.
**example:** `mvn -DskipTests=true -Dport=8081 clean compile hpi:hpi hpi:run`

Please see [JENKINS-64408](https://issues.jenkins.io/browse/JENKINS-64408) for the background and motivation of this.