### PR TITLE
Use the project’s basedir to run `git rev-parse HEAD`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -921,7 +921,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         }
 
         try {
-            Process p = new ProcessBuilder("git", "rev-parse", "HEAD").redirectErrorStream(true).start();
+            Process p = new ProcessBuilder("git", "-C", git.getAbsolutePath(), "rev-parse", "HEAD").redirectErrorStream(true).start();
             p.getOutputStream().close();
             String v = IOUtils.toString(p.getInputStream()).trim();
             if (p.waitFor()!=0)


### PR DESCRIPTION
I was puzzled to see (non-incrementalified) plugins labelled e.g. `1.15-SNAPSHOT (private-abcd1234-jglick)` apparently referring to a commit not present in the plugin repository. Finally figured out that these were real commits, in _another_ repository from which I was running e.g.

```bash
mvn -f ../something-plugin -Pquick-build clean package
java -jar jenkins-cli.jar install-plugin = -restart < ../something-plugin/target/something.hpi
```
