### PR TITLE
Link to `/doc/developer/plugin-development/mark-a-plugin-incompatible/`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -60,7 +60,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     /**
      * Optional - the oldest version of this plugin which the current version is
      * configuration-compatible with.
-     * @see <a href="Mark a new plugin version as incompatible with older versions">https://www.jenkins.io/doc/developer/plugin-development/mark-a-plugin-incompatible/</a>
+     * @see <a href="https://www.jenkins.io/doc/developer/plugin-development/mark-a-plugin-incompatible/">Mark a new plugin version as incompatible with older versions</a>
      */
     @Parameter(property = "hpi.compatibleSinceVersion")
     private String compatibleSinceVersion;

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -60,6 +60,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     /**
      * Optional - the oldest version of this plugin which the current version is
      * configuration-compatible with.
+     * @see <a href="Mark a new plugin version as incompatible with older versions">https://www.jenkins.io/doc/developer/plugin-development/mark-a-plugin-incompatible/</a>
      */
     @Parameter(property = "hpi.compatibleSinceVersion")
     private String compatibleSinceVersion;


### PR DESCRIPTION
@daniel-beck pointed me to this replacement for https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions.
