### PR TITLE
Use `mojo-executor`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+        <groupId>org.twdata.maven</groupId>
+        <artifactId>mojo-executor</artifactId>
+        <version>2.3.2</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Addresses this long-standing comment from commit commit ee161c7:

> All I want to do here is to invoke the hpl target. there must be a better way to do this!
> jglick: perhaps https://github.com/TimMoore/mojo-executor would work?

Indeed, it would.