### PR TITLE
Fix deprecated `@Component` annotation warnings

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -28,7 +28,7 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
     /**
      * The maven project.
      */
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
     @Parameter(defaultValue = "${session}", required = true, readonly = true)

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
@@ -231,7 +231,7 @@ public abstract class AbstractJettyMojo extends AbstractMojo
     /**
      * The maven project.
      */
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RecordCoreLocationMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RecordCoreLocationMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -31,7 +32,7 @@ import org.apache.maven.project.MavenProject;
 @Mojo(name="record-core-location", defaultPhase=LifecyclePhase.PACKAGE)
 public class RecordCoreLocationMojo extends AbstractMojo  {
 
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
     @Component

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
@@ -53,7 +53,7 @@ public class TagLibInterfaceGeneratorMojo extends AbstractMojo {
     /**
      * The maven project.
      */
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
     /**


### PR DESCRIPTION
Fixes the following build warnings:

```
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.RunMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.RecordCoreLocationMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.TestDependencyMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.HplMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.JarMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.ValidateHpiMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.AssembleDependenciesMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.TestInsertionMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.TagLibInterfaceGeneratorMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.WarMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.HpiMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.ValidateMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.TestHplMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
[WARNING] Deprecated @Component annotation for 'project' field in org.jenkinsci.maven.plugins.hpi.ListPluginDependenciesMojo: replace with @Parameter( defaultValue = "${project}", readonly = true )
```