### PR TITLE
Use name for `Specification-Title` instead of description.

### DIFF
--- a/src/it/JENKINS-45740-metadata/pom.xml
+++ b/src/it/JENKINS-45740-metadata/pom.xml
@@ -11,6 +11,11 @@
     <artifactId>JENKINS-45740-metadata</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
+    <name>JENKINS-45740 name</name>
+    <description>
+      JENKINS-45740 description.
+      On two lines.
+    </description>
     <properties>
         <java.level>8</java.level>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>

--- a/src/it/JENKINS-45740-metadata/verify.groovy
+++ b/src/it/JENKINS-45740-metadata/verify.groovy
@@ -28,6 +28,13 @@ checkArtifact(
       'Plugin-License-Url': 'https://opensource.org/licenses/MIT',
       'Plugin-License-Name-2': 'MY License',
       'Plugin-License-Url-2': 'https://mylicense.txt',
+      'Extension-Name': 'JENKINS-45740-metadata',
+      'Implementation-Title': 'JENKINS-45740-metadata',
+      'Implementation-Version': '1.0-SNAPSHOT',
+      'Specification-Title': 'JENKINS-45740 name',
+      'Group-Id': 'org.jenkins-ci.tools.hpi.its',
+      'Short-Name': 'JENKINS-45740-metadata',
+      'Long-Name': 'JENKINS-45740 name',
     ])
 
 return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -121,8 +121,7 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
             mainSection.addAttributeAndCheck(
                     new Manifest.Attribute("Implementation-Vendor", project.getOrganization().getName()));
         }
-        mainSection.addAttributeAndCheck(
-                new Manifest.Attribute("Specification-Title", project.getDescription()));
+        mainSection.addAttributeAndCheck(new Manifest.Attribute("Specification-Title", pluginName));
         if (project.getOrganization() != null) {
             mainSection.addAttributeAndCheck(
                     new Manifest.Attribute("Specification-Vendor", project.getOrganization().getName()));


### PR DESCRIPTION
Follows up https://github.com/jenkinsci/maven-hpi-plugin/pull/251

Project description ends up being displayed in the plugin manager
(rendered in a html block). It can span multiple lines. Such information
can be long and doesn't really fit in the manifest. Use the name
instead.

Also completed coverage for manifest content.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
