### PR TITLE
Ignore Jetty 10.x and 11.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Must remain within Jetty 9.x until Java 8 support is removed
+      - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
+        versions: [">=10.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Should avoid the likes of #288. Matches

https://github.com/jenkinsci/jenkins/blob/f0089728741e3ebbf752f938b8bbd16d1e492b24/.github/dependabot.yml#L37-L39