### PR TITLE
Remove usages of `StringUtils`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -85,7 +84,7 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
                      && (a.getArtifactId().equals("jenkins-core") || a.getArtifactId().equals("hudson-core"));
 
             if (match) {
-                if (StringUtils.isNotBlank(jenkinsCoreVersionOverride)) {
+                if (jenkinsCoreVersionOverride != null && !jenkinsCoreVersionOverride.trim().isEmpty()) {
                     VersionNumber v1 = new VersionNumber(a.getVersion());
                     VersionNumber v2 = new VersionNumber(jenkinsCoreVersionOverride);
                     if (v1.compareTo(v2) == -1) {
@@ -98,7 +97,7 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
                 return a.getVersion();
             }
         }
-        if (StringUtils.isNotBlank(jenkinsCoreVersionOverride)) {
+        if (jenkinsCoreVersionOverride != null && !jenkinsCoreVersionOverride.trim().isEmpty()) {
             return jenkinsCoreVersionOverride;
         }
         throw new MojoExecutionException("Failed to determine Jenkins version this plugin depends on.");

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -18,7 +18,7 @@ package org.jenkinsci.maven.plugins.hpi;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.commons.lang.StringUtils;
+import java.util.Objects;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
@@ -109,16 +109,16 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
         Manifest manifest = loadManifest(manifestFile);
 
         getLog().info("Checking for attached .jar artifact "
-                + (StringUtils.isBlank(jarClassifier) ? "..." : "with classifier " + jarClassifier + "..."));
+                + (jarClassifier == null || jarClassifier.trim().isEmpty() ? "..." : "with classifier " + jarClassifier + "..."));
         File jarFile = null;
         for (Artifact artifact: project.getAttachedArtifacts()) {
-            if (StringUtils.equals(project.getGroupId(), artifact.getGroupId())
-                    && StringUtils.equals(project.getArtifactId(), artifact.getArtifactId())
+            if (Objects.equals(project.getGroupId(), artifact.getGroupId())
+                    && Objects.equals(project.getArtifactId(), artifact.getArtifactId())
                     && project.getArtifact().getVersionRange().equals(artifact.getVersionRange())
-                    && StringUtils.equals("jar", artifact.getType())
-                    && (StringUtils.isBlank(jarClassifier)
+                    && Objects.equals("jar", artifact.getType())
+                    && (jarClassifier == null || jarClassifier.trim().isEmpty()
                     ? !artifact.hasClassifier()
-                    : StringUtils.equals(jarClassifier, artifact.getClassifier()))
+                    : Objects.equals(jarClassifier, artifact.getClassifier()))
                     && artifact.getFile() != null && artifact.getFile().isFile()) {
                 jarFile = artifact.getFile();
                 getLog().info("Found attached .jar artifact: " + jarFile.getAbsolutePath());

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.maven.plugins.hpi;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.model.Resource;
@@ -93,7 +92,7 @@ public class HplMojo extends AbstractJenkinsManifestMojo {
 
             buildLibraries(paths);
 
-            mainSection.addAttributeAndCheck(new Attribute("Libraries", StringUtils.join(paths, ",")));
+            mainSection.addAttributeAndCheck(new Attribute("Libraries", String.join(",", paths)));
 
             // compute Resource-Path entry
             if (webappDirectory != null && webappDirectory.isDirectory()) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -242,7 +241,7 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
                 return type;
             }
             // also ignore core-assets, tests, etc.
-            if (!StringUtils.isEmpty(artifact.getClassifier())) {
+            if (artifact.getClassifier() != null && !artifact.getClassifier().isEmpty()) {
                 return type;
             }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -17,7 +17,6 @@ package org.jenkinsci.maven.plugins.hpi;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -769,12 +768,12 @@ public class RunMojo extends AbstractJettyMojo {
 
     @Override
     public void startJetty() throws MojoExecutionException {
-        if (httpConnector == null && (defaultPort != 0 || StringUtils.isNotEmpty(defaultHost))) {
+        if (httpConnector == null && (defaultPort != 0 || (defaultHost != null && !defaultHost.isEmpty()))) {
             httpConnector = new MavenServerConnector();
             if (defaultPort != 0) {
                 httpConnector.setPort(defaultPort);
             }
-            if (StringUtils.isNotEmpty(defaultHost)) {
+            if (defaultHost != null && !defaultHost.isEmpty()) {
                 httpConnector.setHost(defaultHost);
             }
             String browserHost;

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
@@ -13,7 +13,6 @@ import com.sun.codemodel.writer.FileCodeWriter;
 import com.sun.codemodel.writer.FilterCodeWriter;
 import groovy.lang.Closure;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -114,7 +113,8 @@ public class TagLibInterfaceGeneratorMojo extends AbstractMojo {
         }
 
         if (isTagLibDir(dir)) {
-            JDefinedClass c = pkg.parent()._interface(StringUtils.capitalize(h2j(dir.getName())) + "TagLib");
+            String taglib = h2j(dir.getName());
+            JDefinedClass c = pkg.parent()._interface(taglib.substring(0, 1).toUpperCase() + taglib.substring(1) + "TagLib");
             c._implements(TypedTagLibrary.class);
             c.annotate(TagLibraryUri.class).param("value",dirName);
 


### PR DESCRIPTION
The fewer third-party dependencies we have, the easier maintenance becomes. This PR removes usages of the third-party `StringUtils` class in favor of native Java Platform functionality.