### PR TITLE
Fix `RV_CHECK_COMPARETO_FOR_SPECIFIC_RETURN_VALUE` SpotBugs violation

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
@@ -74,7 +74,7 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
             if (jenkinsTestHarness != null) {
                 try {
                     ArtifactVersion version = jenkinsTestHarness.getSelectedVersion();
-                    if (version == null || version.compareTo(new DefaultArtifactVersion("2.14")) == -1) {
+                    if (version == null || version.compareTo(new DefaultArtifactVersion("2.14")) < 0) {
                         getLog().info(
                                 "Skipping " + project.getName()
                                         + " because it's not <packaging>hpi</packaging> and the " + jenkinsTestHarnessId


### PR DESCRIPTION
Fixes the following SpotBugs violation:

```
[ERROR] Medium: Check to see if return value of org.apache.maven.artifact.versioning.ArtifactVersion.compareTo(Object) is equal to -1 [org.jenkinsci.maven.plugins.hpi.TestInsertionMojo] At TestInsertionMojo.java:[line 77] RV_CHECK_COMPARETO_FOR_SPECIFIC_RETURN_VALUE
```