### PR TITLE
Fix `OS_OPEN_STREAM` SpotBugs violation

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
@@ -45,7 +45,10 @@ public class ValidateHpiMojo extends AbstractHpiMojo {
     private VersionNumber getDependencyCoreVersion(MavenArtifact artifact) throws IOException, MojoExecutionException {
         File file = artifact.getFile();
         if (file.isFile()) {
-            Attributes mainAttributes = new JarFile(file).getManifest().getMainAttributes();
+            Attributes mainAttributes;
+            try (JarFile jarFile = new JarFile(file)) {
+                mainAttributes = jarFile.getManifest().getMainAttributes();
+            }
             Attributes.Name jName = new Attributes.Name("Jenkins-Version");
             if (mainAttributes.containsKey(jName)) {
                 return new VersionNumber(mainAttributes.getValue(jName));


### PR DESCRIPTION
Fixes the following SpotBugs violation:

```
[ERROR] Medium: org.jenkinsci.maven.plugins.hpi.ValidateHpiMojo.getDependencyCoreVersion(MavenArtifact) may fail to close stream [org.jenkinsci.maven.plugins.hpi.ValidateHpiMojo] At ValidateHpiMojo.java:[line 48] OS_OPEN_STREAM
```