### PR TITLE
Fix `RV_RETURN_VALUE_IGNORED_BAD_PRACTICE` SpotBugs violations

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -334,13 +334,25 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         throws MojoExecutionException {
         getLog().info("Exploding webapp...");
 
-        webappDirectory.mkdirs();
+        try {
+            Files.createDirectories(webappDirectory.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create directories for '" + webappDirectory + "'", e);
+        }
 
         File webinfDir = new File(webappDirectory, WEB_INF);
-        webinfDir.mkdirs();
+        try {
+            Files.createDirectories(webinfDir.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create directories for '" + webinfDir + "'", e);
+        }
 
         File metainfDir = new File(webappDirectory, META_INF);
-        metainfDir.mkdirs();
+        try {
+            Files.createDirectories(metainfDir.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create directories for '" + metainfDir + "'", e);
+        }
 
         try {
             List<Resource> webResources = this.webResources != null ? Arrays.asList(this.webResources) : null;
@@ -621,8 +633,12 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         File tempLocation = new File(workDirectory, name.substring(0, name.length() - 4));
 
         boolean process = false;
-        if (!tempLocation.exists()) {
-            tempLocation.mkdirs();
+        if (!Files.isDirectory(tempLocation.toPath())) {
+            try {
+                Files.createDirectories(tempLocation.toPath());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to create directories for '" + tempLocation + "'", e);
+            }
             process = true;
         } else if (artifact.getFile().lastModified() > tempLocation.lastModified()) {
             process = true;
@@ -681,16 +697,25 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         scanner.scan();
 
         for (String dir : scanner.getIncludedDirectories()) {
-            new File(targetDir, dir).mkdirs();
+            File includeDir = new File(targetDir, dir);
+            try {
+                Files.createDirectories(includeDir.toPath());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to create directories for '" + includeDir + "'", e);
+            }
         }
 
         for (String file : scanner.getIncludedFiles()) {
             File targetFile = new File(targetDir, file);
 
             // Do not overwrite existing files.
-            if (!targetFile.exists()) {
+            if (!Files.exists(targetFile.toPath())) {
                 try {
-                    targetFile.getParentFile().mkdirs();
+                    Files.createDirectories(targetFile.toPath().getParent());
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Failed to create parent directories for '" + targetFile + "'", e);
+                }
+                try {
                     FileUtils.copyFileIfModified(new File(srcDir, file), targetFile);
                 }
                 catch (IOException e) {
@@ -776,7 +801,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
         Writer fileWriter = null;
         try {
             // fix for MWAR-36, ensures that the parent dir are created first
-            to.getParentFile().mkdirs();
+            Files.createDirectories(to.toPath().getParent());
 
             if (encoding == null || encoding.length() < 1) {
                 fileReader = Files.newBufferedReader(from.toPath(), StandardCharsets.UTF_8);

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -82,8 +82,13 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
      */
     protected void generateManifest(MavenArchiveConfiguration archive, File manifestFile) throws MojoExecutionException {
         // create directory if it doesn't exist yet
-        if (!manifestFile.getParentFile().exists())
-            manifestFile.getParentFile().mkdirs();
+        if (!Files.isDirectory(manifestFile.toPath().getParent())) {
+            try {
+                Files.createDirectories(manifestFile.toPath().getParent());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to create parent directories for '" + manifestFile + "'", e);
+            }
+        }
 
         getLog().info("Generating " + manifestFile);
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJettyMojo.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -591,8 +592,9 @@ public abstract class AbstractJettyMojo extends AbstractMojo
         {
             File target = new File(project.getBuild().getDirectory());
             File tmp = new File(target, "jetty");
-            if (!tmp.exists())
-                tmp.mkdirs();            
+            if (!Files.isDirectory(tmp.toPath())) {
+                Files.createDirectories(tmp.toPath());
+            }
             webApp.setTempDirectory(tmp);
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
@@ -39,6 +39,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
@@ -77,7 +78,7 @@ public class TagLibInterfaceGeneratorMojo extends AbstractMojo {
                 walk(new File(res.getDirectory()),codeModel.rootPackage(),"");
             }
 
-            outputDirectory.mkdirs();
+            Files.createDirectories(outputDirectory.toPath());
             CodeWriter w = new FilterCodeWriter(encoding != null ? new FileCodeWriter(outputDirectory, encoding) : new FileCodeWriter(outputDirectory)) {
                 // Cf. ProgressCodeWriter:
                 @Override public Writer openSource(JPackage pkg, String fileName) throws IOException {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * Places test-dependency plugins into somewhere the test harness can pick up.
@@ -25,12 +26,14 @@ import java.nio.charset.StandardCharsets;
 public class TestDependencyMojo extends AbstractHpiMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        File testDir = new File(project.getBuild().getTestOutputDirectory(),"test-dependencies");
-        testDir.mkdirs();
-
+        File testDir = new File(project.getBuild().getTestOutputDirectory(), "test-dependencies");
         try {
-            Writer w = new OutputStreamWriter(new FileOutputStream(new File(testDir,"index")), StandardCharsets.UTF_8);
+            Files.createDirectories(testDir.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create directories for '" + testDir + "'", e);
+        }
 
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(new File(testDir, "index")), StandardCharsets.UTF_8)) {
             for (MavenArtifact a : getProjectArtfacts()) {
                 if (!a.isPluginBestEffort(getLog()))
                     continue;
@@ -46,8 +49,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 FileUtils.copyFile(a.getHpi().getFile(),dst);
                 w.write(artifactId + "\n");
             }
-
-            w.close();
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to copy dependency plugins",e);
         }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -33,7 +33,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             throw new MojoExecutionException("Failed to create directories for '" + testDir + "'", e);
         }
 
-        try (Writer w = new OutputStreamWriter(new FileOutputStream(new File(testDir, "index")), StandardCharsets.UTF_8)) {
+        try (FileOutputStream fos = new FileOutputStream(new File(testDir, "index")); Writer w = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
             for (MavenArtifact a : getProjectArtfacts()) {
                 if (!a.isPluginBestEffort(getLog()))
                     continue;

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestHplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestHplMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Generate .hpl file in the test class directory so that test harness can locate the plugin.
@@ -25,7 +26,11 @@ public class TestHplMojo extends HplMojo {
     @Override
     protected File computeHplFile() throws MojoExecutionException {
         File testDir = new File(project.getBuild().getTestOutputDirectory());
-        testDir.mkdirs();
+        try {
+            Files.createDirectories(testDir.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create directories for '" + testDir + "'", e);
+        }
         File theHpl = new File(testDir,"the.hpl");
         if (project.getArtifact().isSnapshot()) {
             try {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojo.java
@@ -2,11 +2,13 @@ package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -107,7 +109,7 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
 
         try {
             File f = new File(project.getBasedir(), "target/generated-test-sources/injected");
-            f.mkdirs();
+            Files.createDirectories(f.toPath());
             File javaFile = new File(f, injectedTestName + ".java");
             PrintWriter w = new PrintWriter(new OutputStreamWriter(new FileOutputStream(javaFile), StandardCharsets.UTF_8));
             w.println("import java.util.*;");
@@ -135,9 +137,9 @@ public class TestInsertionMojo extends AbstractJenkinsMojo {
 
             // always set the same time stamp on this file, so that Maven will not re-compile this
             // every time we run this mojo.
-            javaFile.setLastModified(0);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
+            Files.setLastModifiedTime(javaFile.toPath(), FileTime.fromMillis(0L));
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to create injected tests", e);
         }
     }
 }


### PR DESCRIPTION
Fixes the following SpotBugs violations:

```
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo.buildExplodedWebapp(File, File) [org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo, org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo, org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo] At AbstractHpiMojo.java:[line 337]Another occurrence at AbstractHpiMojo.java:[line 340]Another occurrence at AbstractHpiMojo.java:[line 343] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo.copyDependentWarContents(File, File) [org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo, org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo] At AbstractHpiMojo.java:[line 684]Another occurrence at AbstractHpiMojo.java:[line 693] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo.copyFilteredFile(File, File, String, AbstractHpiMojo$FilterWrapper[], Properties) [org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo] At AbstractHpiMojo.java:[line 779] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo.unpackWarToTempDirectory(MavenArtifact) [org.jenkinsci.maven.plugins.hpi.AbstractHpiMojo] At AbstractHpiMojo.java:[line 625] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractJenkinsManifestMojo.generateManifest(MavenArchiveConfiguration, File) [org.jenkinsci.maven.plugins.hpi.AbstractJenkinsManifestMojo] At AbstractJenkinsManifestMojo.java:[line 86] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.AbstractJettyMojo.configureWebApplication() [org.jenkinsci.maven.plugins.hpi.AbstractJettyMojo] At AbstractJettyMojo.java:[line 595] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.delete() ignored in org.jenkinsci.maven.plugins.hpi.RunMojo.copyPlugin(File, File, String) [org.jenkinsci.maven.plugins.hpi.RunMojo] At RunMojo.java:[line 468] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.renameTo(File) ignored in org.jenkinsci.maven.plugins.hpi.RunMojo.copyPlugin(File, File, String) [org.jenkinsci.maven.plugins.hpi.RunMojo] At RunMojo.java:[line 455] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.RunMojo.execute() [org.jenkinsci.maven.plugins.hpi.RunMojo] At RunMojo.java:[line 364] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.TagLibInterfaceGeneratorMojo.execute() [org.jenkinsci.maven.plugins.hpi.TagLibInterfaceGeneratorMojo] At TagLibInterfaceGeneratorMojo.java:[line 80] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.TestDependencyMojo.execute() [org.jenkinsci.maven.plugins.hpi.TestDependencyMojo] At TestDependencyMojo.java:[line 29] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.TestHplMojo.computeHplFile() [org.jenkinsci.maven.plugins.hpi.TestHplMojo] At TestHplMojo.java:[line 28] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.mkdirs() ignored in org.jenkinsci.maven.plugins.hpi.TestInsertionMojo.execute() [org.jenkinsci.maven.plugins.hpi.TestInsertionMojo] At TestInsertionMojo.java:[line 110] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[ERROR] Medium: Exceptional return value of java.io.File.setLastModified(long) ignored in org.jenkinsci.maven.plugins.hpi.TestInsertionMojo.execute() [org.jenkinsci.maven.plugins.hpi.TestInsertionMojo] At TestInsertionMojo.java:[line 138] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
```