### PR TITLE
Record `maven-invoker-plugin` failures via `junit` rather than console

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,10 @@ properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
 node('maven') {
     checkout scm
     timeout(time: 1, unit: 'HOURS') {
-        // TODO Azure mirror
         ansiColor('xterm') {
             withEnv(['MAVEN_OPTS=-Djansi.force=true']) {
-                sh 'mvn -B -Dstyle.color=always -ntp -Prun-its clean install site'
+                sh 'mvn -B -Dstyle.color=always -ntp -Prun-its -Dmaven.test.failure.ignore clean install site'
+                junit 'target/invoker-reports/TEST-*.xml'
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -319,8 +319,6 @@
           <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
           <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
           <settingsFile>src/it/settings.xml</settingsFile>
-          <showErrors>true</showErrors>
-          <streamLogs>true</streamLogs>
           <pomIncludes>
             <pomInclude>*/pom.xml</pomInclude>
           </pomIncludes>
@@ -328,6 +326,10 @@
           <filterProperties>
             <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
           </filterProperties>
+          <environmentVariables>
+            <!-- block anything set by a CI environment -->
+            <JENKINS_HOME />
+          </environmentVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -411,13 +413,6 @@
                   <goal>install</goal>
                   <goal>run</goal>
                 </goals>
-                <configuration>
-                  <streamLogs>true</streamLogs>
-                  <environmentVariables>
-                    <!-- block anything set by a CI environment -->
-                    <JENKINS_HOME />
-                  </environmentVariables>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -435,6 +430,29 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>all-tests</id>
+      <activation>
+        <property>
+          <name>!invoker.test</name>
+        </property>
+      </activation>
+      <properties>
+        <invoker.writeJunitReport>true</invoker.writeJunitReport>
+        <invoker.junitPackageName>io.jenkins.tools.maven_hpi_plugin.its</invoker.junitPackageName>
+      </properties>
+    </profile>
+    <profile>
+      <id>specific-tests</id>
+      <activation>
+        <property>
+          <name>invoker.test</name>
+        </property>
+      </activation>
+      <properties>
+        <invoker.streamLogs>true</invoker.streamLogs>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/it/JENKINS-45740-metadata/invoker.properties
+++ b/src/it/JENKINS-45740-metadata/invoker.properties
@@ -1,3 +1,3 @@
 # install, not verify, because we want to check the artifact as we would be about to deploy it
 # release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean install
+invoker.goals=-ntp -Pjenkins-release -Drelease.skipTests=false clean install

--- a/src/it/JENKINS-58771-packaged-plugins-2/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins-2/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=-Dstyle.color=always -ntp clean install
+invoker.goals=-ntp clean install

--- a/src/it/JENKINS-58771-packaged-plugins-3/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins-3/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=-Dstyle.color=always -ntp clean install
+invoker.goals=-ntp clean install

--- a/src/it/JENKINS-58771-packaged-plugins/invoker.properties
+++ b/src/it/JENKINS-58771-packaged-plugins/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=-Dstyle.color=always -ntp clean install
+invoker.goals=-ntp clean install

--- a/src/it/assemble-dependencies-as-jpi/invoker.properties
+++ b/src/it/assemble-dependencies-as-jpi/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean generate-resources
+invoker.goals=-ntp clean generate-resources

--- a/src/it/assemble-dependencies/invoker.properties
+++ b/src/it/assemble-dependencies/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean generate-resources
+invoker.goals=-ntp clean generate-resources

--- a/src/it/check-core-version-failure/invoker.properties
+++ b/src/it/check-core-version-failure/invoker.properties
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp validate
+invoker.goals=-ntp validate
 invoker.buildResult = failure

--- a/src/it/check-core-version-success/invoker.properties
+++ b/src/it/check-core-version-success/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp validate
+invoker.goals=-ntp validate

--- a/src/it/compile-fork-it/invoker.properties
+++ b/src/it/compile-fork-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean compile
+invoker.goals=-ntp clean compile

--- a/src/it/compile-it/invoker.properties
+++ b/src/it/compile-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean compile
+invoker.goals=-ntp clean compile

--- a/src/it/compile-multimodule-it/invoker.properties
+++ b/src/it/compile-multimodule-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean compile
+invoker.goals=-ntp clean compile

--- a/src/it/parent-3x/invoker.properties
+++ b/src/it/parent-3x/invoker.properties
@@ -1,3 +1,3 @@
 # install, not verify, because we want to check the artifact as we would be about to deploy it
 # release.skipTests normally set in jenkins-release profile since release:perform would do the tests
-invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean install hpi:run
+invoker.goals=-ntp -Pjenkins-release -Drelease.skipTests=false clean install hpi:run

--- a/src/it/process-jar/invoker.properties
+++ b/src/it/process-jar/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean verify
+invoker.goals=-ntp clean verify

--- a/src/it/snapshot-version-override/invoker.properties
+++ b/src/it/snapshot-version-override/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean verify
+invoker.goals=-ntp clean verify

--- a/src/it/verify-it/invoker.properties
+++ b/src/it/verify-it/invoker.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-invoker.goals=-Dstyle.color=always -ntp clean verify
+invoker.goals=-ntp clean verify


### PR DESCRIPTION
Inspired by a change in https://github.com/jenkinsci/plugin-pom/pull/508. Rather than streaming all the IT logs to the Jenkins build log, capture them in JUnit-format test results instead, and treat any failures as an unstable build. Should make it easier to develop #66 and the like.
