### PR TITLE
Enforce existence of `src/main/resources/index.jelly`

### DIFF
--- a/src/it/missing-index/invoker.properties
+++ b/src/it/missing-index/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp clean package
+invoker.buildResult=failure

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.37</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>missing-index</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>MyNewPlugin</name>
+    <description>Deprecated spot for plugin description.</description>
+    <properties>
+        <jenkins.version>2.222.4</jenkins.version>
+        <java.level>8</java.level>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+</project>

--- a/src/it/missing-index/src/main/java/org/jenkinsci/tools/hpi/its/X.java
+++ b/src/it/missing-index/src/main/java/org/jenkinsci/tools/hpi/its/X.java
@@ -1,0 +1,2 @@
+package org.jenkinsci.tools.hpi.its;
+public class X {}

--- a/src/it/missing-index/verify.groovy
+++ b/src/it/missing-index/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'build.log').getText('UTF-8').contains("create src/main/resources/index.jelly:");
+
+return true;


### PR DESCRIPTION
See https://github.com/jenkinsci/junit-attachments-plugin/pull/28 for example.
