### PR TITLE
[JENKINS-67912] Maven HPI plugin does not compile with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+    <aether.version>1.1.0</aether.version>
     <maven.version>3.8.5</maven.version>
     <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
     <plexus-containers.version>2.1.1</plexus-containers.version>
@@ -92,6 +93,16 @@
         <artifactId>maven-shared-utils</artifactId>
         <version>3.3.4</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-api</artifactId>
+        <version>${aether.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-util</artifactId>
+        <version>${aether.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -114,6 +125,11 @@
       <!-- stapler plugin pulls jaxen pulls ancient ver that blows up annotation processing -->
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.codemodel</groupId>
       <artifactId>codemodel</artifactId>
       <version>2.6</version>
@@ -127,6 +143,11 @@
       <groupId>net.java.sezpoz</groupId>
       <artifactId>sezpoz</artifactId>
       <version>1.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.10.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -186,23 +207,6 @@
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
       <version>1.9</version>
-    </dependency>
-    <!-- for using annotation processor -->
-    <dependency>
-      <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>maven-stapler-plugin</artifactId>
-      <version>1.17</version>
-      <!-- make sure to exclude servlet so that the one in Jetty (which has different groupId) will win -->
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kohsuke.stapler</groupId>
-          <artifactId>stapler</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
@@ -284,25 +288,13 @@
               <rules>
                 <requireUpperBoundDeps>
                   <excludes combine.children="append">
-                    <exclude>com.google.guava:guava</exclude>
-                    <exclude>com.google.inject:guice</exclude>
-                    <exclude>commons-beanutils:commons-beanutils</exclude>
-                    <exclude>commons-codec:commons-codec</exclude>
                     <exclude>commons-io:commons-io</exclude>
                     <exclude>commons-lang:commons-lang</exclude>
                     <exclude>org.apache.commons:commons-compress</exclude>
                     <exclude>org.apache.commons:commons-lang3</exclude>
-                    <exclude>org.apache.httpcomponents:httpclient</exclude>
-                    <exclude>org.apache.httpcomponents:httpcore</exclude>
-                    <exclude>org.apache.maven.doxia:doxia-decoration-model</exclude>
-                    <exclude>org.apache.maven:maven-project</exclude>
                     <exclude>org.apache.maven.wagon:wagon-provider-api</exclude>
                     <exclude>org.codehaus.plexus:plexus-container-default</exclude>
-                    <exclude>org.eclipse.aether:aether-util</exclude>
-                    <exclude>org.ow2.asm:asm</exclude>
                     <exclude>org.slf4j:slf4j-api</exclude>
-                    <exclude>xerces:xercesImpl</exclude>
-                    <exclude>xml-apis:xml-apis</exclude>
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -11,8 +11,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 
 import java.util.List;
@@ -57,6 +57,9 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.remoteArtifactRepositories}",readonly = true, required = true)
     protected List<ArtifactRepository> remoteRepos;
 
+    @Parameter(defaultValue = "${project.pluginArtifactRepositories}", readonly = true, required = true)
+    protected List<ArtifactRepository> pluginArtifactRepositories;
+
     @Component
     @Parameter(defaultValue = "${localRepository}", readonly = true, required = true)
     protected ArtifactRepository localRepository;
@@ -68,7 +71,7 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
     protected ArtifactResolver artifactResolver;
 
     @Component
-    protected MavenProjectBuilder projectBuilder;
+    protected ProjectBuilder projectBuilder;
 
     @Component
     protected MavenProjectHelper projectHelper;
@@ -110,6 +113,7 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
                 artifactFactory,
                 projectBuilder,
                 remoteRepos,
+                pluginArtifactRepositories,
                 localRepository,
                 session);
     }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -39,7 +39,7 @@ import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
@@ -196,7 +196,7 @@ public class RunMojo extends AbstractJettyMojo {
     protected boolean consoleForceReload;
 
     @Component
-    protected MavenProjectBuilder projectBuilder;
+    protected ProjectBuilder projectBuilder;
 
     /**
      * Optional string that represents "groupId:artifactId" of Jenkins core jar.
@@ -845,6 +845,7 @@ public class RunMojo extends AbstractJettyMojo {
                 artifactFactory,
                 projectBuilder,
                 getProject().getRemoteArtifactRepositories(),
+                getProject().getPluginArtifactRepositories(),
                 localRepository,
                 session);
     }


### PR DESCRIPTION
### Problem

See [JENKINS-67912](https://issues.jenkins.io/browse/JENKINS-67912). When compiling `maven-hpi-plugin` with Java 11, the build fails:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.0:compile (default-compile) on project maven-hpi-plugin: Compilation failure
[ERROR] java.nio.file.NoSuchFileException: jenkinsci/maven-hpi-plugin/target/classes/META-INF/exposed.stapler-beans
[ERROR] 
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.0:compile (default-compile) on project maven-hpi-plugin: Compilation failure
java.nio.file.NoSuchFileException: jenkinsci/maven-hpi-plugin/target/classes/META-INF/exposed.stapler-beans

    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.compiler.CompilationFailureException: Compilation failure
java.nio.file.NoSuchFileException: jenkinsci/maven-hpi-plugin/target/classes/META-INF/exposed.stapler-beans

    at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute (AbstractCompilerMojo.java:1300)
    at org.apache.maven.plugin.compiler.CompilerMojo.execute (CompilerMojo.java:198)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

### Evaluation

This error seems to be caused by the use of `maven-stapler-plugin` as a direct dependency. The comment states: "for using annotation processor", but this seems to be outdated. The logic dates from commit 334506f from 2007, and the annotation logic was ripped out in commit 334506f in 2012. So this dependency is just no longer needed. Plugins and core consume `maven-stapler-plugin` through their respective parent POMs. This is not needed in `maven-hpi-plugin`.

### Solution

Remove `maven-stapler-plugin`. This opens a can of worms, as it seems we were unintentionally relying on `maven-stapler-plugin` to pull in:

- Ant
- Guava
- Maven 2 (!)

So now we explicitly depend on the latest versions of Ant and Guava (which we consume directly) and rewrite any usages of Maven 2 in terms of the equivalent Maven 3 APIs.

### Implementation

The main Maven 2 API we were still consuming was `org.apache.maven.project.MavenProjectBuilder#buildFromRepository`. This PR rewrites our usages in terms of the Maven 3 API `org.apache.maven.project.ProjectBuilder#build` instead.

### Testing done

I tested this both from plugins and core. In the case of core I verified that the `generate-taglib-interface` Mojo still produced the same results as before. In the case of plugins I verified that the resulting `.hpi` had the same contents as before and that `mvn hpi:run` still worked as before.

Fixes #286