### PR TITLE
Avoid copying `session.projectBuildingRequest` unless overriding something

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -3,7 +3,6 @@ package org.jenkinsci.maven.plugins.hpi;
 import hudson.util.VersionNumber;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
@@ -14,8 +13,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
-
-import java.util.List;
 
 /**
  * Mojos that need to figure out the Jenkins version it's working with.
@@ -49,17 +46,6 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
      */
     @Parameter
     private String jenkinsCoreVersionOverride;
-
-
-    /**
-     * List of Remote Repositories used by the resolver
-     */
-    @Parameter(defaultValue = "${project.remoteArtifactRepositories}",readonly = true, required = true)
-    protected List<ArtifactRepository> remoteRepos;
-
-    @Component
-    @Parameter(defaultValue = "${localRepository}", readonly = true, required = true)
-    protected ArtifactRepository localRepository;
 
     @Component
     protected ArtifactFactory artifactFactory;
@@ -109,8 +95,6 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
                 artifactResolver,
                 artifactFactory,
                 projectBuilder,
-                remoteRepos,
-                localRepository,
                 session);
     }
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/WarMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/WarMojo.java
@@ -7,10 +7,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Zip;
@@ -86,11 +84,7 @@ public class WarMojo extends RunMojo {
 
                 // find corresponding .hpi file
                 Artifact hpi = artifactFactory.createArtifact(a.getGroupId(),a.getArtifactId(),a.getVersion(),null,"hpi");
-                ProjectBuildingRequest buildingRequest =
-                        new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-                buildingRequest.setRemoteRepositories(getProject().getRemoteArtifactRepositories());
-                buildingRequest.setLocalRepository(localRepository);
-                hpi = artifactResolver.resolveArtifact(buildingRequest, hpi).getArtifact();
+                hpi = artifactResolver.resolveArtifact(session.getProjectBuildingRequest(), hpi).getArtifact();
 
                 if (hpi.getFile().isDirectory())
                     throw new UnsupportedOperationException(hpi.getFile()+" is a directory and not packaged yet. this isn't supported");


### PR DESCRIPTION
As proposed in https://github.com/jenkinsci/maven-hpi-plugin/pull/310#discussion_r832214118, cleaning up some code mostly introduced in #247 or which at least could have been simplified at that time. Creating a `DefaultProjectBuildingRequest` based on the `session.projectBuildingRequest` makes sense if you actually need to override some property. Otherwise it just copies properties from the original. And that means `${localRepository}` and `${project.remoteArtifactRepositories}` should not need to be injected; pick those things up from the `session`.
