### PR TITLE
Modernize tests

### DIFF
--- a/src/it/JENKINS-45740-metadata/pom.xml
+++ b/src/it/JENKINS-45740-metadata/pom.xml
@@ -5,13 +5,15 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>4.38</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>JENKINS-45740-metadata</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
         <!--Examples of real use-cases-->
@@ -20,16 +22,16 @@
     </properties>
 
     <licenses>
-      <license>
-        <name>MIT License</name>
-        <url>https://opensource.org/licenses/MIT</url>
-        <distribution>repo</distribution>
-      </license>
-      <license>
-        <name>MY License</name>
-        <url>https://mylicense.txt</url>
-        <comments>Hello, world!</comments>
-      </license>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>MY License</name>
+            <url>https://mylicense.txt</url>
+            <comments>Hello, world!</comments>
+        </license>
     </licenses>
 
     <repositories>
@@ -46,9 +48,9 @@
     </pluginRepositories>
 
     <scm>
-      <connection>scm:git:git://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
-      <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-      <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/src/it/JENKINS-45740-metadata/pom.xml
+++ b/src/it/JENKINS-45740-metadata/pom.xml
@@ -48,7 +48,7 @@
     </pluginRepositories>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifctId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>HEAD</tag>

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -5,15 +5,16 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.38</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>JENKINS-58771-packaged-plugins</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
-        <jenkins.version>2.176.1</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
     </properties>
 
@@ -40,21 +41,42 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-<!--            +- org.jenkins-ci.plugins.workflow:workflow-cps:jar:2.76:compile-->
-<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.22:compile-->
-<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-api:jar:2.37:compile-->
-<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-support:jar:3.3:compile-->
-<!--            |  |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:compile-->
-<!--            |  |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:compile-->
+<!--            +- org.jenkins-ci.plugins.workflow:workflow-cps:jar:2.94:compile -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.23:compile -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-api:jar:2.46:compile -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-support:jar:3.8:compile -->
+<!--            |  |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:compile -->
+<!--            |  |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:compile -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-scm-step:jar:2.13:compile -->
+<!--            |  +- org.jenkins-ci.plugins:script-security:jar:1.77:compile -->
+<!--            |  |  +- org.kohsuke:groovy-sandbox:jar:1.27:compile -->
+<!--            |  |  \- io.jenkins.plugins:caffeine-api:jar:2.9.1-23.v51c4e2c879c8:compile -->
+<!--            |  |     \- com.github.ben-manes.caffeine:caffeine:jar:2.9.1:compile -->
+<!--            |  +- org.jenkins-ci.plugins:scm-api:jar:2.6.4:compile -->
+<!--            |  +- org.jenkins-ci.plugins:structs:jar:1.23:compile -->
+<!--            |  |  \- org.jenkins-ci:symbol-annotation:jar:1.23:compile -->
+<!--            |  +- com.cloudbees:groovy-cps:jar:1.32:compile -->
+<!--            |  +- org.jenkins-ci.ui:ace-editor:jar:1.1:compile -->
+<!--            |  \- com.cloudbees:diff4j:jar:1.3:compile -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
-<!--            +- org.jenkins-ci.plugins.workflow:workflow-support:jar:tests:3.3:test-->
-<!--            |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:compile-->
-<!--            |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:compile-->
+<!--            +- org.jenkins-ci.plugins.workflow:workflow-support:jar:tests:3.8:test -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.23:test -->
+<!--            |  |  \- org.jenkins-ci.plugins:structs:jar:1.20:test -->
+<!--            |  |     \- org.jenkins-ci:symbol-annotation:jar:1.20:test -->
+<!--            |  +- org.jenkins-ci.plugins.workflow:workflow-api:jar:2.40:test -->
+<!--            |  +- org.jenkins-ci.plugins:scm-api:jar:2.6.4:test -->
+<!--            |  +- org.jenkins-ci.plugins:script-security:jar:1.75:test -->
+<!--            |  |  +- org.kohsuke:groovy-sandbox:jar:1.27:test -->
+<!--            |  |  \- com.github.ben-manes.caffeine:caffeine:jar:2.8.2:test -->
+<!--            |  |     +- org.checkerframework:checker-qual:jar:3.3.0:test -->
+<!--            |  |     \- com.google.errorprone:error_prone_annotations:jar:2.3.4:test -->
+<!--            |  \- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:test -->
+<!--            |     \- org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:test -->
         </dependency>
     </dependencies>
 
@@ -62,8 +84,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>5</version>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
@@ -6,15 +6,17 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>3.57</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>JENKINS-58771-packaged-plugins</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
-        <jenkins.version>2.176.1</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
+        <enforcer.skip>true</enforcer.skip>
     </properties>
 
     <repositories>
@@ -49,15 +51,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>5</version>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/it/JENKINS-58771-packaged-plugins/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins/pom.xml
@@ -5,15 +5,16 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>4.38</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>JENKINS-58771-packaged-plugins</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
-        <jenkins.version>2.176.1</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
     </properties>
 
@@ -34,13 +35,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-extensions</artifactId>
-            <version>1.3.7</version>
         </dependency>
     </dependencies>
 
@@ -48,8 +47,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.176.2</version>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/it/assemble-dependencies-as-jpi/pom.xml
+++ b/src/it/assemble-dependencies-as-jpi/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -9,11 +10,17 @@
 
   <packaging>pom</packaging>
 
+  <properties>
+    <jenkins.version>2.249.1</jenkins.version>
+    <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.10</version>
+      <version>1.19</version>
     </dependency>
   </dependencies>
   
@@ -23,7 +30,6 @@
       <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/src/it/assemble-dependencies/pom.xml
+++ b/src/it/assemble-dependencies/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -9,11 +10,17 @@
 
   <packaging>pom</packaging>
 
+  <properties>
+    <jenkins.version>2.249.1</jenkins.version>
+    <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.10</version>
+      <version>1.19</version>
     </dependency>
   </dependencies>
   
@@ -23,7 +30,6 @@
       <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/src/it/check-core-version-failure/pom.xml
+++ b/src/it/check-core-version-failure/pom.xml
@@ -5,38 +5,28 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.6</version>
+    <version>4.38</version>
     <relativePath />
   </parent>
   <artifactId>check-core-version-failure</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
-    <jenkins.version>2.204</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.11.2</version>
+      <version>2.13.2-260.v43d711474c77</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1.36</version>
+      <version>1414.v878271fc496f</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/src/it/check-core-version-failure/verify.groovy
+++ b/src/it/check-core-version-failure/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains("Dependency org.jenkins-ci.plugins:jackson2-api:jar:2.11.2 requires Jenkins 2.222.4 or higher.")
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Dependency io.jenkins:configuration-as-code:jar:1414.v878271fc496f requires Jenkins 2.289.3 or higher.")
 
 return true;

--- a/src/it/check-core-version-success/pom.xml
+++ b/src/it/check-core-version-success/pom.xml
@@ -5,32 +5,22 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.6</version>
+    <version>4.38</version>
     <relativePath />
   </parent>
   <artifactId>check-core-version-success</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
-    <jenkins.version>2.222.4</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.11.2</version>
+      <version>2.13.2-260.v43d711474c77</version>
     </dependency>
   </dependencies>
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/src/it/compile-fork-it/pom.xml
+++ b/src/it/compile-fork-it/pom.xml
@@ -1,44 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    
-    <modelVersion>4.0.0</modelVersion>
+
+  <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>4.38</version>
+    <relativePath />
   </parent>
 
-    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
-    <artifactId>compile-it</artifactId>
-    <version>1.0-SNAPSHOT</version>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>compile-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
-    <packaging>hpi</packaging>
+  <packaging>hpi</packaging>
 
-    <name>MyNewPlugin</name>
+  <name>MyNewPlugin</name>
+
+  <properties>
+    <jenkins.version>2.249.1</jenkins.version>
+    <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+  </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-          <configuration>
-            <fork>true</fork>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>access-modifier-checker</artifactId>
-          <version>1.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
+        <configuration>
+          <fork>true</fork>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/it/compile-it/pom.xml
+++ b/src/it/compile-it/pom.xml
@@ -1,12 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
     <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.424</version>
-  </parent>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.38</version>
+        <relativePath />
+    </parent>
 
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>compile-it</artifactId>
@@ -16,28 +18,9 @@
 
     <name>MyNewPlugin</name>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-        <plugin>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>access-modifier-checker</artifactId>
-          <version>1.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
-      </plugin>
-    </plugins>
-  </build>
-
+    <properties>
+        <jenkins.version>2.249.1</jenkins.version>
+        <java.level>8</java.level>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
 </project>

--- a/src/it/compile-multimodule-it/plugin1/pom.xml
+++ b/src/it/compile-multimodule-it/plugin1/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
   <modelVersion>4.0.0</modelVersion>

--- a/src/it/compile-multimodule-it/plugin2/pom.xml
+++ b/src/it/compile-multimodule-it/plugin2/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
   <modelVersion>4.0.0</modelVersion>

--- a/src/it/compile-multimodule-it/pom.xml
+++ b/src/it/compile-multimodule-it/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
   <modelVersion>4.0.0</modelVersion>
@@ -5,7 +6,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.25</version>
+    <version>4.38</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -14,24 +16,13 @@
 
   <packaging>pom</packaging>
   <properties>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
   </properties>
 
   <modules>
     <module>plugin1</module>
     <module>plugin2</module>
   </modules>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
 </project>

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.37</version>
-        <relativePath/>
+        <version>4.38</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>missing-index</artifactId>
@@ -13,7 +14,7 @@
     <name>MyNewPlugin</name>
     <description>Deprecated spot for plugin description.</description>
     <properties>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
     </properties>

--- a/src/it/parent-3x/pom.xml
+++ b/src/it/parent-3x/pom.xml
@@ -5,17 +5,18 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.29</version>
-        <relativePath/>
+        <version>3.57</version>
+        <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>parent-3x</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
+        <enforcer.skip>true</enforcer.skip>
         <no-test-jar>false</no-test-jar>
     </properties>
     <repositories>
@@ -34,7 +35,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.5</version>
+            <version>308.v852b473a2b8c</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/it/parent-3x/verify.groovy
+++ b/src/it/parent-3x/verify.groovy
@@ -25,7 +25,7 @@ checkArtifact(installed, 'parent-3x-1.0-SNAPSHOT.hpi',
     ['WEB-INF/lib/parent-3x.jar'],
     // TODO still some problems with unwanted transitive JAR dependencies creeping in, e.g. WEB-INF/lib/jboss-marshalling-1.4.9.Final.jar in workflow-multibranch.hpi, or all kinds of junk in parameterized-trigger.hpi
     ['test/SampleRootAction.class', 'WEB-INF/lib/symbol-annotation-1.5.jar'],
-    ['Short-Name': 'parent-3x', 'Group-Id': 'org.jenkins-ci.tools.hpi.its', 'Jenkins-Version': '2.60.3' /* Plugin-Version unpredictable for a snapshot */, 'Plugin-Dependencies': 'structs:1.5'])
+    ['Short-Name': 'parent-3x', 'Group-Id': 'org.jenkins-ci.tools.hpi.its', 'Jenkins-Version': '2.249.1' /* Plugin-Version unpredictable for a snapshot */, 'Plugin-Dependencies': 'structs:308.v852b473a2b8c'])
 
 checkArtifact(installed, 'parent-3x-1.0-SNAPSHOT.jar',
     ['META-INF/annotations/hudson.Extension', 'test/SampleRootAction.class', 'index.jelly'],

--- a/src/it/process-jar/pom.xml
+++ b/src/it/process-jar/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -6,7 +7,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>4.38</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -16,8 +18,9 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
   </properties>
 
   <name>MyNewPlugin</name>
@@ -26,21 +29,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.8</version>
+      <version>2.13.2.1</version>
       <optional>true</optional>
     </dependency>
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>@project.groupId@</groupId>
@@ -91,7 +85,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jarsigner-plugin</artifactId>
-        <version>1.4</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>sign</id>

--- a/src/it/process-jar/verify.groovy
+++ b/src/it/process-jar/verify.groovy
@@ -25,9 +25,9 @@ assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its/HelloWorldB
 assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its/HelloWorldBuilder$DescriptorImpl.class').exists();
 assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its/HelloWorldBuilder.stapler').exists();
 assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its/Messages.class').exists();
-assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-annotations-2.6.0.jar').exists();
-assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-core-2.6.3.jar').exists();
-assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-databind-2.6.3').exists();
+assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-annotations-2.13.2').exists();
+assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-core-2.13.2.jar').exists();
+assert !new File(basedir, 'target/process-jar/WEB-INF/lib/jackson-databind-2.13.2.1.jar').exists();
 assert new File(basedir, 'target/process-jar.hpi').exists();
 assert new File(basedir, 'target/process-jar.jar').exists();
 

--- a/src/it/snapshot-version-override/pom.xml
+++ b/src/it/snapshot-version-override/pom.xml
@@ -1,24 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    
-    <modelVersion>4.0.0</modelVersion>
+
+  <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>4.38</version>
+    <relativePath />
   </parent>
 
-    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
-    <artifactId>snapshot-version-override</artifactId>
-    <version>1.x-SNAPSHOT</version>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>snapshot-version-override</artifactId>
+  <version>1.x-SNAPSHOT</version>
 
-    <packaging>hpi</packaging>
+  <packaging>hpi</packaging>
 
-    <name>MyNewPlugin</name>
+  <name>MyNewPlugin</name>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
   </properties>
 
   <scm>
@@ -29,15 +32,6 @@
   </scm>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.github.stephenc.continuous</groupId>
@@ -58,7 +52,6 @@
       <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
         <configuration>
           <snapshotPluginVersionOverride>${actual-version}</snapshotPluginVersionOverride>
         </configuration>

--- a/src/it/verify-it/pom.xml
+++ b/src/it/verify-it/pom.xml
@@ -1,12 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
     <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>3.29</version>
-  </parent>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.38</version>
+        <relativePath />
+    </parent>
 
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
     <artifactId>verify-it</artifactId>
@@ -16,28 +18,9 @@
 
     <name>MyNewPlugin</name>
 
-  <properties>
-    <jenkins.version>2.60.3</jenkins.version>
-    <java.level>8</java.level>
-  </properties>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>@project.groupId@</groupId>
-          <artifactId>@project.artifactId@</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>@project.version@</version>
-      </plugin>
-    </plugins>
-  </build>
-
+    <properties>
+        <jenkins.version>2.249.1</jenkins.version>
+        <java.level>8</java.level>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
 </project>


### PR DESCRIPTION
The tests for this component were using ancient versions of Jenkins core and the plugin parent POM. This PR updates the tests to use relatively recent versions of Jenkins core and the plugin parent POM for more realistic testing.