### PR TITLE
Add default manifest entries with Maven

### DIFF
--- a/src/it/verify-it/pom.xml
+++ b/src/it/verify-it/pom.xml
@@ -17,6 +17,30 @@
     <packaging>hpi</packaging>
 
     <name>MyNewPlugin</name>
+    <description>My New Plugin</description>
+    <url>https://github.com/jenkinsci/maven-hpi-plugin</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>nchomsky</id>
+            <name>Noam Chomsky</name>
+            <email>nchomsky@example.com</email>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/maven-hpi-plugin.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jenkinsci/maven-hpi-plugin</url>
+    </scm>
 
     <properties>
         <jenkins.version>2.249.1</jenkins.version>

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+import java.io.InputStream
+import java.nio.file.Files
+import java.util.jar.Manifest
+
 assert new File(basedir, 'target/classes').exists();
 assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its').exists();
 assert new File(basedir, 'target/classes/org/jenkinsci/tools/hpi/its/HelloWorldBuilder.class').exists();
@@ -30,6 +34,34 @@ assert new File(basedir, 'target/generated-sources/localizer/org/jenkinsci/tools
 
 content = new File(basedir, 'target/generated-sources/localizer/org/jenkinsci/tools/hpi/its/Messages.java').text;
 assert content.contains(" holder.format(\"it.msg\");");
+
+assert new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').exists()
+
+InputStream is = Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').toPath())
+try {
+  Manifest manifest = new Manifest(is)
+  assert !manifest.getMainAttributes().getValue('Build-Jdk-Spec').isEmpty()
+  assert manifest.getMainAttributes().getValue('Created-By').startsWith('Maven Archiver')
+  assert manifest.getMainAttributes().getValue('Extension-Name') == null // was provided by Maven 2, but core prefers Short-Name
+  assert manifest.getMainAttributes().getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its')
+  assert manifest.getMainAttributes().getValue('Hudson-Version').equals('2.249.1')
+  assert manifest.getMainAttributes().getValue('Implementation-Title').equals('MyNewPlugin') // was project.artifactId in previous versions, now project.name
+  assert manifest.getMainAttributes().getValue('Implementation-Version').equals('1.0-SNAPSHOT')
+  assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.249.1')
+  assert manifest.getMainAttributes().getValue('Long-Name').equals('MyNewPlugin')
+  assert manifest.getMainAttributes().getValue('Manifest-Version').equals('1.0')
+  assert manifest.getMainAttributes().getValue('Minimum-Java-Version').equals('1.8')
+  assert manifest.getMainAttributes().getValue('Plugin-Developers').equals('Noam Chomsky:nchomsky:nchomsky@example.com')
+  assert manifest.getMainAttributes().getValue('Plugin-License-Name').equals('MIT License')
+  assert manifest.getMainAttributes().getValue('Plugin-License-Url').equals('https://opensource.org/licenses/MIT')
+  assert manifest.getMainAttributes().getValue('Plugin-ScmUrl').equals('https://github.com/jenkinsci/maven-hpi-plugin')
+  assert manifest.getMainAttributes().getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
+  assert manifest.getMainAttributes().getValue('Short-Name').equals('verify-it')
+  assert manifest.getMainAttributes().getValue('Specification-Title').equals('MyNewPlugin') // was project.description in previous versions, now project.name
+  assert manifest.getMainAttributes().getValue('Url').equals('https://github.com/jenkinsci/maven-hpi-plugin')
+} finally {
+  is.close()
+}
 
 // TODO add some test on hpi file content
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.maven.plugins.hpi;
 
+import org.apache.maven.archiver.ManifestConfiguration;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
@@ -96,7 +97,10 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
         ma.setOutputFile(manifestFile);
 
         try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(manifestFile), StandardCharsets.UTF_8))) {
-            Manifest mf = ma.getManifest(project, archive.getManifest());
+            ManifestConfiguration config = archive.getManifest();
+            config.setAddDefaultSpecificationEntries(true);
+            config.setAddDefaultImplementationEntries(true);
+            Manifest mf = ma.getManifest(project, config);
             Manifest.ExistingSection mainSection = mf.getMainSection();
             setAttributes(mainSection);
 
@@ -114,23 +118,6 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
             in.close();
 
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Plugin-Class",pluginClassName));
-        }
-
-        mainSection.addAttributeAndCheck(
-                new Manifest.Attribute("Extension-Name", project.getArtifactId()));
-        mainSection.addAttributeAndCheck(
-                new Manifest.Attribute("Implementation-Title", project.getArtifactId()));
-        mainSection.addAttributeAndCheck(
-                new Manifest.Attribute("Implementation-Version", project.getVersion()));
-        if (project.getOrganization() != null) {
-            mainSection.addAttributeAndCheck(
-                    new Manifest.Attribute("Implementation-Vendor", project.getOrganization().getName()));
-        }
-        mainSection.addAttributeAndCheck(
-                new Manifest.Attribute("Specification-Title", project.getDescription()));
-        if (project.getOrganization() != null) {
-            mainSection.addAttributeAndCheck(
-                    new Manifest.Attribute("Specification-Vendor", project.getOrganization().getName()));
         }
 
         mainSection.addAttributeAndCheck(new Manifest.Attribute("Group-Id",project.getGroupId()));


### PR DESCRIPTION
Cleans up a small amount of technical debt introduced in #251 during the transition to Maven 3. Supersedes #284. With this PR, we rely on Maven to add the default specification entries and default implementation entries to the manifest. This allows us to remove some ugly copypasta.

This change is not 100% backward-compatible, but it should be safe for the reasons given in the comments.