### PR TITLE
Improve validation mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.10-rc142.172b_43188179</version> <!-- TODO https://github.com/jenkinsci/lib-version-number/pull/41 -->
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.9</version>
+      <version>1.10-rc142.172b_43188179</version> <!-- TODO https://github.com/jenkinsci/lib-version-number/pull/41 -->
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import java.util.Properties;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.execution.MavenSession;
@@ -12,7 +14,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 
 /**
  * Mojos that need to figure out the Jenkins version it's working with.
@@ -87,6 +92,39 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
             return jenkinsCoreVersionOverride;
         }
         throw new MojoExecutionException("Failed to determine Jenkins version this plugin depends on.");
+    }
+
+    protected JavaSpecificationVersion getMinimumJavaVersion() throws MojoExecutionException {
+        Artifact bom = resolveJenkinsCoreBom(findJenkinsVersion());
+
+        Properties properties;
+        try {
+            properties = wrap(bom).resolvePom().getProperties();
+        } catch (ProjectBuildingException e) {
+            throw new MojoExecutionException("Failed to resolve artifact " + bom, e);
+        }
+
+        String version = properties.getProperty("java.level");
+        if (version == null || version.isEmpty()) {
+            throw new MojoExecutionException("java.level not defined in " + bom);
+        }
+        return new JavaSpecificationVersion(version);
+    }
+
+    private Artifact resolveJenkinsCoreBom(String version) throws MojoExecutionException {
+        DefaultArtifactCoordinate artifactCoordinate = new DefaultArtifactCoordinate();
+        artifactCoordinate.setGroupId("org.jenkins-ci.main");
+        artifactCoordinate.setArtifactId("jenkins-bom");
+        artifactCoordinate.setVersion(version);
+        artifactCoordinate.setExtension("pom");
+
+        try {
+            return artifactResolver
+                    .resolveArtifact(session.getProjectBuildingRequest(), artifactCoordinate)
+                    .getArtifact();
+        } catch (ArtifactResolverException e) {
+            throw new MojoExecutionException("Couldn't download artifact: ", e);
+        }
     }
 
     protected MavenArtifact wrap(Artifact a) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.maven.plugins.hpi;
 
 import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -13,24 +13,16 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
 public class ValidateMojo extends AbstractJenkinsMojo {
+
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        if (!isMustangOrAbove())
-            throw new MojoExecutionException("JDK6 or later is necessary to build a Jenkins plugin");
+    public void execute() throws MojoExecutionException {
+        JavaSpecificationVersion javaVersion = getMinimumJavaVersion();
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(javaVersion)) {
+            throw new MojoExecutionException("Java " + javaVersion + " or later is necessary to build this plugin.");
+        }
 
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("1.419.99"))<=0)
-            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 1.420 or later");
-    }
-
-    /**
-     * Are we running on JDK6 or above?
-     */
-    private static boolean isMustangOrAbove() {
-        try {
-            Class.forName("javax.annotation.processing.Processor");
-            return true;
-        } catch(ClassNotFoundException e) {
-            return false;
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
+            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
         }
     }
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -21,7 +21,7 @@ public class ValidateMojo extends AbstractJenkinsMojo {
             throw new MojoExecutionException("Java " + javaVersion + " or later is necessary to build this plugin.");
         }
 
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.204")) < 0) {
             throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
         }
     }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -16,13 +16,13 @@ public class ValidateMojo extends AbstractJenkinsMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
-            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
-        }
-
         JavaSpecificationVersion javaVersion = getMinimumJavaVersion();
         if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(javaVersion)) {
             throw new MojoExecutionException("Java " + javaVersion + " or later is necessary to build this plugin.");
+        }
+
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
+            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
         }
     }
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -16,13 +16,13 @@ public class ValidateMojo extends AbstractJenkinsMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
+            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
+        }
+
         JavaSpecificationVersion javaVersion = getMinimumJavaVersion();
         if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(javaVersion)) {
             throw new MojoExecutionException("Java " + javaVersion + " or later is necessary to build this plugin.");
-        }
-
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.203.99")) <= 0) {
-            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.204 or later");
         }
     }
 }


### PR DESCRIPTION
The validation mojo currently checks for Java 6 or later and Jenkins 1.420 or later. These seem like pretty old minimum requirements.

This PR bumps the minimum supported core version to 2.204 and enforces minimum Java version based on the value encoded by core, at whatever version of core the plugin is running against. The only place this is encoded right now is in `java.level` in `core-bom`, which is where we're reading it (well, `MANIFEST.MF` in `jenkins.war` encodes a `Build-Jdk-Spec`, but that could be problematic if you did a local build with Java 11 and `<release>8</release>`, so I am not relying on it). I don't feel strongly about encoding it in this particular way, just that it is encoded _somewhere_ in the artifacts published by core and that we read it out here. If we want to encode it some other way I am fine with that.

I tested this by building core with a `java.level` of 11 and verifying that a plugin gave us the proper error message. No integration tests yet, because it is too hard to integration test all of this stuff across multiple repositories when stuff hasn't been released. When releases have been made and everything is updated, I think it will be far easier to add test coverage.

@jglick Curious what you think in the context of our other discussions elsewhere. No pressure to review this though.