### PR TITLE
Print warning if using deprecated `java.level` with new enough parent POM

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -24,6 +24,8 @@ public class ValidateMojo extends AbstractJenkinsMojo {
 
         MavenProject parent = project.getParent();
         if (parent != null
+                && parent.getGroupId().equals("org.jenkins-ci.plugins")
+                && parent.getArtifactId().equals("plugin")
                 && !parent.getProperties().containsKey("java.level")
                 && project.getProperties().containsKey("java.level")) {
             getLog().warn("Ignoring deprecated java.level property."

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -5,6 +5,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Make sure that we are running in the right environment.
@@ -20,6 +21,15 @@ public class ValidateMojo extends AbstractJenkinsMojo {
 
         if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("1.419.99"))<=0)
             throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 1.420 or later");
+
+        MavenProject parent = project.getParent();
+        if (parent != null
+                && !parent.getProperties().containsKey("java.level")
+                && project.getProperties().containsKey("java.level")) {
+            getLog().warn("Ignoring deprecated java.level property."
+                    + " This property should be removed from your plugin's POM."
+                    + " In the future this warning will be changed to an error and will break the build.");
+        }
     }
 
     /**


### PR DESCRIPTION
Tested manually with https://github.com/jenkinsci/plugin-pom/pull/522