### PR TITLE
Dynamically apply `Add-Opens` directives from `MANIFEST.MF`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsMojo.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.maven.plugins.hpi;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import java.io.DataInputStream;
@@ -8,7 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.jar.JarFile;
-import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -132,37 +130,6 @@ public abstract class AbstractJenkinsMojo extends AbstractMojo {
             artifactCoordinate.setArtifactId("jenkins-core");
         }
         artifactCoordinate.setVersion(findJenkinsVersion());
-
-        try {
-            return artifactResolver
-                    .resolveArtifact(session.getProjectBuildingRequest(), artifactCoordinate)
-                    .getArtifact();
-        } catch (ArtifactResolverException e) {
-            throw new MojoExecutionException("Couldn't download artifact: ", e);
-        }
-    }
-
-    @CheckForNull
-    protected String getAddOpens() throws MojoExecutionException {
-        Artifact artifact = resolveJenkinsWar();
-        File war = wrap(artifact).getFile();
-        try (JarFile jarFile = new JarFile(war)) {
-            Manifest manifest = jarFile.getManifest();
-            if (manifest == null) {
-                throw new MojoExecutionException("No manifest found in " + war);
-            }
-            return manifest.getMainAttributes().getValue("Add-Opens");
-        } catch (IOException e) {
-            throw new MojoExecutionException("Failed to read MANIFEST.MF from " + war, e);
-        }
-    }
-
-    private Artifact resolveJenkinsWar() throws MojoExecutionException {
-        DefaultArtifactCoordinate artifactCoordinate = new DefaultArtifactCoordinate();
-        artifactCoordinate.setGroupId("org.jenkins-ci.main");
-        artifactCoordinate.setArtifactId("jenkins-war");
-        artifactCoordinate.setVersion(findJenkinsVersion());
-        artifactCoordinate.setExtension("war");
 
         try {
             return artifactResolver

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.maven.plugins.hpi;
+
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Configure Maven for the desired version of Java.
+ *
+ * @author Basil Crow
+ */
+@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
+public class InitializeMojo extends AbstractJenkinsMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        String addOpens = getAddOpens();
+        if (addOpens != null
+                && JavaSpecificationVersion.forCurrentJVM().isNewerThanOrEqualTo(new JavaSpecificationVersion("9"))) {
+            String argLine = project.getProperties().getProperty("argLine");
+            if (argLine != null) {
+                argLine += " " + buildargLine(addOpens);
+            } else {
+                argLine = buildargLine(addOpens);
+            }
+            getLog().info("Setting argLine to " + argLine);
+            project.getProperties().setProperty("argLine", argLine);
+        }
+    }
+
+    private static String buildargLine(String addOpens) {
+        List<String> arguments = new ArrayList<>();
+        for (String module : addOpens.split("\\s+")) {
+            if (!module.isEmpty()) {
+                arguments.add("--add-opens");
+                arguments.add(module + "=ALL-UNNAMED");
+            }
+        }
+        return String.join(" ", arguments);
+    }
+}

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -17,18 +17,29 @@ public class InitializeMojo extends AbstractJenkinsMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        String addOpens = getAddOpens();
-        if (addOpens != null
-                && JavaSpecificationVersion.forCurrentJVM().isNewerThanOrEqualTo(new JavaSpecificationVersion("9"))) {
-            String argLine = project.getProperties().getProperty("argLine");
-            if (argLine != null) {
-                argLine += " " + buildArgLine(addOpens);
-            } else {
-                argLine = buildArgLine(addOpens);
-            }
-            getLog().info("Setting argLine to " + argLine);
-            project.getProperties().setProperty("argLine", argLine);
+        setSurefireProperties();
+    }
+
+    private void setSurefireProperties() throws MojoExecutionException {
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new JavaSpecificationVersion("9"))) {
+            // nothing to do
+            return;
         }
+
+        String addOpens = getAddOpens();
+        if (addOpens == null) {
+            // core older than 2.339, ignore
+            return;
+        }
+
+        String argLine = project.getProperties().getProperty("argLine");
+        if (argLine != null) {
+            argLine += " " + buildArgLine(addOpens);
+        } else {
+            argLine = buildArgLine(addOpens);
+        }
+        getLog().info("Setting argLine to " + argLine);
+        project.getProperties().setProperty("argLine", argLine);
     }
 
     private static String buildArgLine(String addOpens) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -34,35 +34,19 @@ public class InitializeMojo extends AbstractJenkinsMojo {
             return;
         }
 
-        String addOpens = getAddOpens();
-        if (addOpens == null) {
+        String manifestEntry = getManifestEntry();
+        if (manifestEntry == null) {
             // core older than 2.339, ignore
             return;
         }
 
-        String argLine = project.getProperties().getProperty("argLine");
-        if (argLine != null) {
-            argLine += " " + buildArgLine(addOpens);
-        } else {
-            argLine = buildArgLine(addOpens);
-        }
-        getLog().info("Setting argLine to " + argLine);
-        project.getProperties().setProperty("argLine", argLine);
-    }
-
-    private static String buildArgLine(String addOpens) {
-        List<String> arguments = new ArrayList<>();
-        for (String module : addOpens.split("\\s+")) {
-            if (!module.isEmpty()) {
-                arguments.add("--add-opens");
-                arguments.add(module + "=ALL-UNNAMED");
-            }
-        }
-        return String.join(" ", arguments);
+        String argLine = buildArgLine(manifestEntry);
+        getLog().info("Setting jenkins.addOpens to " + argLine);
+        project.getProperties().setProperty("jenkins.addOpens", argLine);
     }
 
     @CheckForNull
-    private String getAddOpens() throws MojoExecutionException {
+    private String getManifestEntry() throws MojoExecutionException {
         Artifact artifact = resolveJenkinsWar();
         File war = wrap(artifact).getFile();
         try (JarFile jarFile = new JarFile(war)) {
@@ -90,5 +74,16 @@ public class InitializeMojo extends AbstractJenkinsMojo {
         } catch (ArtifactResolverException e) {
             throw new MojoExecutionException("Couldn't download artifact: ", e);
         }
+    }
+
+    private static String buildArgLine(String manifestEntry) {
+        List<String> arguments = new ArrayList<>();
+        for (String module : manifestEntry.split("\\s+")) {
+            if (!module.isEmpty()) {
+                arguments.add("--add-opens");
+                arguments.add(module + "=ALL-UNNAMED");
+            }
+        }
+        return String.join(" ", arguments);
     }
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -22,16 +22,16 @@ public class InitializeMojo extends AbstractJenkinsMojo {
                 && JavaSpecificationVersion.forCurrentJVM().isNewerThanOrEqualTo(new JavaSpecificationVersion("9"))) {
             String argLine = project.getProperties().getProperty("argLine");
             if (argLine != null) {
-                argLine += " " + buildargLine(addOpens);
+                argLine += " " + buildArgLine(addOpens);
             } else {
-                argLine = buildargLine(addOpens);
+                argLine = buildArgLine(addOpens);
             }
             getLog().info("Setting argLine to " + argLine);
             project.getProperties().setProperty("argLine", argLine);
         }
     }
 
-    private static String buildargLine(String addOpens) {
+    private static String buildArgLine(String addOpens) {
         List<String> arguments = new ArrayList<>();
         for (String module : addOpens.split("\\s+")) {
             if (!module.isEmpty()) {

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -12,6 +12,7 @@
             <id>default</id>
             <phases>
               <validate>org.jenkins-ci.tools:maven-hpi-plugin:validate,org.jenkins-ci.tools:maven-hpi-plugin:validate-hpi</validate>
+              <initialize>org.jenkins-ci.tools:maven-hpi-plugin:initialize</initialize>
               <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
               <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
               <process-classes>org.kohsuke:access-modifier-checker:enforce</process-classes>


### PR DESCRIPTION
Currently, people testing with Java 17 must add an awkward `-DargLine=` directive with the `Add-Opens` modules from the core version they are testing. This PR applies a trick to dynamically set this based on the values in `MANIFEST.MF`.

With this in place, anyone with a sufficiently recent core (2.341+), test harness (1721.v385389722736+), and `maven-hpi-plugin` (this PR) should be able to effortlessly do Java 17 testing and indeed enable Java 17 in their `Jenkinsfile`. Once this is merged, I will try to do a release and wrap this and the test harness change into a new plugin POM release so that the requirement just becomes "core 2.341+ and plugin POM 4.40+".

Tested with `workflow-job` and Java 17:

```
$ mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.job.WorkflowJobTest,org.jenkinsci.plugins.workflow.job.WorkflowRunTest -Djenkins.version=2.341 -Djenkins-test-harness.version=1723.vcd938b_e66072 -Dhpi-plugin.version=3.27-SNAPSHOT -Denforcer.skip
[…]
[INFO] --- maven-hpi-plugin:3.27-SNAPSHOT:initialize (default-initialize) @ workflow-job ---
[INFO] Setting argLine to -Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
[…]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2022-03-30T11:21:40-07:00
[INFO] ------------------------------------------------------------------------
$
```