### PR TITLE
Dynamically configure Java compiler based on core

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -1,0 +1,75 @@
+package org.jenkinsci.maven.plugins.hpi;
+
+import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Configure Maven for the desired version of Java.
+ *
+ * @author Basil Crow
+ */
+@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
+public class InitializeMojo extends AbstractJenkinsMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        setCompilerProperties();
+    }
+
+    private void setCompilerProperties() throws MojoExecutionException {
+        if (!project.getProperties().containsKey("maven.compiler.source")
+                && !project.getProperties().containsKey("maven.compiler.release")) {
+            // On an older plugin parent POM that predates the setting of these values as Maven properties.
+            return;
+        }
+
+        JavaSpecificationVersion javaVersion = getMinimumJavaVersion();
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("9"))) {
+            // Should always be set already, but just in case...
+            setProperty("maven.compiler.source", javaVersion.toString());
+            setProperty("maven.compiler.target", javaVersion.toString());
+            setProperty("maven.compiler.testSource", javaVersion.toString());
+            setProperty("maven.compiler.testTarget", javaVersion.toString());
+            // Should never be set already, but just in case...
+            unsetProperty("maven.compiler.release");
+            unsetProperty("maven.compiler.testRelease");
+        } else {
+            /*
+             * When compiling with a Java 9+ compiler, we always rely on "release" in favor of "source" and "target",
+             * even when compiling to Java 8 bytecode.
+             */
+            setProperty("maven.compiler.release", Integer.toString(javaVersion.toReleaseVersion()));
+            setProperty("maven.compiler.testRelease", Integer.toString(javaVersion.toReleaseVersion()));
+
+            // "release" serves the same purpose as Animal Sniffer.
+            setProperty("animal.sniffer.skip", "true");
+
+            /*
+             * While it does not hurt to have these set to the Java specification version, it is also not needed when
+             * "release" is in use.
+             */
+            unsetProperty("maven.compiler.source");
+            unsetProperty("maven.compiler.target");
+            unsetProperty("maven.compiler.testSource");
+            unsetProperty("maven.compiler.testTarget");
+        }
+    }
+
+    private void setProperty(String key, String value) {
+        String currentValue = project.getProperties().getProperty(key);
+        if (currentValue == null || !currentValue.equals(value)) {
+            getLog().info("Setting " + key + " to " + value);
+            project.getProperties().setProperty(key, value);
+        }
+    }
+
+    private void unsetProperty(String key) {
+        if (project.getProperties().containsKey(key)) {
+            getLog().info("Unsetting " + key);
+            project.getProperties().remove(key);
+        }
+    }
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -12,6 +12,7 @@
             <id>default</id>
             <phases>
               <validate>org.jenkins-ci.tools:maven-hpi-plugin:validate,org.jenkins-ci.tools:maven-hpi-plugin:validate-hpi</validate>
+              <initialize>org.jenkins-ci.tools:maven-hpi-plugin:initialize</initialize>
               <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
               <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
               <process-classes>org.kohsuke:access-modifier-checker:enforce</process-classes>


### PR DESCRIPTION
When combined with https://github.com/jenkinsci/plugin-pom/pull/523 (which this PR doesn't _require_, but rather _benefits from_ if present), this dynamically configures the Java compiler settings based on the core version in use. Although this sort of dynamic configuration may confuse IDEs, the benefit is that it avoids an awkward flag day when we bump the minimum required Java version to 11. Of course, we may still choose to update the plugin parent POM at that point in time for the benefit of IDEs, but having this change widely adopted beforehand would soften the blow.

I've tested this with a minimum Java version of 8 and a minimum Java version of 11, with a version 8 compiler and a version 11 compiler (matrix of 4 test configurations). When using a minimum Java version of 11, I verified that I could use Java 11 features in the plugin. When using a minimum Java version of 11 and a Java 8 compiler, I verified that I got an error. When using a Java 11 compiler, I verified that we were only setting `release` and `testRelease` regardless of whether the minimum Java version was 8 or 11. When using a Java 8 compiler, I verified that we were setting `source`, `target`, `testSource`, and `testTarget` but not `release` or `testRelease`.