### PR TITLE
Skip model validation of resolved POMs

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/MavenArtifact.java
@@ -6,6 +6,7 @@ import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
@@ -53,6 +54,7 @@ public class MavenArtifact implements Comparable<MavenArtifact> {
         ProjectBuildingRequest buildingRequest =
                 new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
         buildingRequest.setProcessPlugins(false); // improve performance
+        buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
         return builder.build(artifact, buildingRequest).getProject();
     }
 


### PR DESCRIPTION
Chases away the new warnings inadvertently introduced in #310:

```
[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ git-client ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 66 source files to /home/basil/src/jenkinsci/git-client-plugin/target/test-classes
[INFO] 
[INFO] --- maven-hpi-plugin:3.27-SNAPSHOT:test-hpl (default-test-hpl) @ git-client ---
[INFO] Generating /home/basil/src/jenkinsci/git-client-plugin/target/test-classes/the.hpl
[INFO] 
[INFO] --- maven-hpi-plugin:3.27-SNAPSHOT:resolve-test-dependencies (default-resolve-test-dependencies) @ git-client ---
[INFO] 
[INFO] --- gmavenplus-plugin:1.13.1:compileTests (test-in-groovy) @ git-client ---
[INFO] No sources specified for compilation. Skipping.
```

Fixes #325.