### PR TITLE
Treat blank properties as unset

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -67,7 +67,8 @@ public class InitializeMojo extends AbstractJenkinsMojo {
     }
 
     private void unsetProperty(String key) {
-        if (project.getProperties().containsKey(key)) {
+        String currentValue = project.getProperties().getProperty(key);
+        if (currentValue != null && !currentValue.isEmpty()) {
             getLog().info("Unsetting " + key);
             project.getProperties().remove(key);
         }


### PR DESCRIPTION
Small fixup that goes along with https://github.com/jenkinsci/plugin-pom/pull/530. That PR blanks out the `source` and `target` properties when using `release`, but this code checks just checks for null rather than null or empty. By making this code check for null or empty, the "magic" of `InitializeMojo` now becomes a no-op against current cores on all versions of Java as of https://github.com/jenkinsci/plugin-pom/pull/530, which I believe was the desired result according to reviewers.