### PR TITLE
Revert JENKINS-20679

### DIFF
--- a/src/it/minimum-java-version/invoker.properties
+++ b/src/it/minimum-java-version/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp clean verify

--- a/src/it/minimum-java-version/pom.xml
+++ b/src/it/minimum-java-version/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.40</version>
+        <relativePath />
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>minimum-java-version</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>MyNewPlugin</name>
+    <properties>
+        <jenkins.version>2.249.1</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <minimumJavaVersion>8</minimumJavaVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/minimum-java-version/src/main/java/org/jenkinsci/tools/hpi/its/X.java
+++ b/src/it/minimum-java-version/src/main/java/org/jenkinsci/tools/hpi/its/X.java
@@ -1,0 +1,2 @@
+package org.jenkinsci.tools.hpi.its;
+public class X {}

--- a/src/it/minimum-java-version/src/main/resources/index.jelly
+++ b/src/it/minimum-java-version/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/minimum-java-version/verify.groovy
+++ b/src/it/minimum-java-version/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Ignoring deprecated minimumJavaVersion parameter. This property should be removed from your plugin's POM. In the future this warning will be changed to an error and will break the build.")
+
+return true

--- a/src/it/process-jar/pom.xml
+++ b/src/it/process-jar/pom.xml
@@ -53,7 +53,6 @@
         </executions>
         <configuration>
           <jarClassifier>shaded</jarClassifier>
-          <minimumJavaVersion>8</minimumJavaVersion>
         </configuration>
       </plugin>
       <!-- TODO the shade plugin doesn't like shading the non-main attached artifacts yet -->

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -48,7 +48,6 @@ Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').
   assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.249.1')
   assert manifest.getMainAttributes().getValue('Long-Name').equals('MyNewPlugin')
   assert manifest.getMainAttributes().getValue('Manifest-Version').equals('1.0')
-  assert manifest.getMainAttributes().getValue('Minimum-Java-Version').equals('1.8')
   assert manifest.getMainAttributes().getValue('Plugin-Developers').equals('Noam Chomsky:nchomsky:nchomsky@example.com')
   assert manifest.getMainAttributes().getValue('Plugin-License-Name').equals('MIT License')
   assert manifest.getMainAttributes().getValue('Plugin-License-Url').equals('https://opensource.org/licenses/MIT')

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -73,6 +73,15 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     private String sandboxStatus;
 
     /**
+     * Specify the minimum version of Java that this plugin requires.
+     *
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    @Parameter
+    protected String minimumJavaVersion;
+
+    /**
      * Generates a manifest file to be included in the .hpi file
      */
     protected void generateManifest(MavenArchiveConfiguration archive, File manifestFile) throws MojoExecutionException {
@@ -123,6 +132,12 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
 
         if (compatibleSinceVersion!=null)
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Compatible-Since-Version", compatibleSinceVersion));
+
+        if (this.minimumJavaVersion != null && !this.minimumJavaVersion.isEmpty()) {
+            getLog().warn("Ignoring deprecated minimumJavaVersion parameter."
+                    + " This property should be removed from your plugin's POM."
+                    + " In the future this warning will be changed to an error and will break the build.");
+        }
 
         if (sandboxStatus!=null)
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Sandbox-Status", sandboxStatus));

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -73,12 +73,6 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     private String sandboxStatus;
 
     /**
-     * Specify the minimum version of Java that this plugin requires.
-     */
-    @Parameter(required = true)
-    protected String minimumJavaVersion;
-
-    /**
      * Generates a manifest file to be included in the .hpi file
      */
     protected void generateManifest(MavenArchiveConfiguration archive, File manifestFile) throws MojoExecutionException {
@@ -129,21 +123,6 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
 
         if (compatibleSinceVersion!=null)
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Compatible-Since-Version", compatibleSinceVersion));
-
-        if (this.minimumJavaVersion == null) {
-            throw new MojoExecutionException("minimumJavaVersion attribute must be set starting from version 2.8");
-        }
-        try {
-            int res = Integer.parseInt(this.minimumJavaVersion);
-            LOGGER.log(Level.INFO, "Minimum Java version for the plugin: {0}", this.minimumJavaVersion);
-        } catch(NumberFormatException ex) {
-            if (this.minimumJavaVersion.equals("1.6") || this.minimumJavaVersion.equals("1.7") || this.minimumJavaVersion.equals("1.8")) {
-                // okay
-            } else {
-                throw new MojoExecutionException("Unsupported Java version string: `" + this.minimumJavaVersion + "`. If you use Java 9 or above, see https://openjdk.java.net/jeps/223");
-            }
-        }
-        mainSection.addAttributeAndCheck(new Manifest.Attribute("Minimum-Java-Version", this.minimumJavaVersion));
 
         if (sandboxStatus!=null)
             mainSection.addAttributeAndCheck(new Manifest.Attribute("Sandbox-Status", sandboxStatus));

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -244,6 +244,15 @@ public class RunMojo extends AbstractJettyMojo {
     private Collection<Logger> loggerReferences; // just to prevent GC
 
     /**
+     * Specify the minimum version of Java that this plugin requires.
+     *
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    @Parameter
+    private String minimumJavaVersion;
+
+    /**
      * The context path for the webapp. Defaults to the
      * name of the webapp's artifact.
      *

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -244,12 +244,6 @@ public class RunMojo extends AbstractJettyMojo {
     private Collection<Logger> loggerReferences; // just to prevent GC
 
     /**
-     * Specify the minimum version of Java that this plugin requires.
-     */
-    @Parameter(required = true)
-    private String minimumJavaVersion;
-
-    /**
      * The context path for the webapp. Defaults to the
      * name of the webapp's artifact.
      *
@@ -497,8 +491,7 @@ public class RunMojo extends AbstractJettyMojo {
                         MojoExecutor.element(MojoExecutor.name("warSourceDirectory"), warSourceDirectory.toString()),
                         MojoExecutor.element(MojoExecutor.name("jenkinsCoreId"), jenkinsCoreId),
                         MojoExecutor.element(MojoExecutor.name("pluginFirstClassLoader"), Boolean.toString(pluginFirstClassLoader)),
-                        MojoExecutor.element(MojoExecutor.name("maskClasses"), maskClasses),
-                        MojoExecutor.element(MojoExecutor.name("minimumJavaVersion"), minimumJavaVersion)),
+                        MojoExecutor.element(MojoExecutor.name("maskClasses"), maskClasses)),
                 MojoExecutor.executionEnvironment(project, session, pluginManager));
     }
 


### PR DESCRIPTION
Reverts #75. See [the mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/V2CH4pNQitQ/m/ZNmNb0x7BwAJ) along with https://github.com/jenkinsci/jenkins/pull/6549 and https://github.com/jenkins-infra/update-center2/pull/591. This is dead code, so we intend to stop producing it from `maven-hpi-plugin` and to stop consuming it from `jenkins` and `update-center2`. A new integration test verifies that we issue a warning if users are still trying to specify this in their build configuration.