### PR TITLE
Handle presence of index.jelly differently

### DIFF
--- a/src/it/missing-index-and-description/invoker.properties
+++ b/src/it/missing-index-and-description/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp clean package
+invoker.buildResult=failure

--- a/src/it/missing-index-and-description/pom.xml
+++ b/src/it/missing-index-and-description/pom.xml
@@ -14,6 +14,6 @@
     <name>MyNewPlugin</name>
     <properties>
         <jenkins.version>2.249.1</jenkins.version>
-        <hpi-plugin.version>3.29-SNAPSHOT</hpi-plugin.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
     </properties>
 </project>

--- a/src/it/missing-index-and-description/pom.xml
+++ b/src/it/missing-index-and-description/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.40</version>
+        <relativePath />
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>missing-index</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>MyNewPlugin</name>
+    <properties>
+        <jenkins.version>2.249.1</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    </properties>
+</project>

--- a/src/it/missing-index-and-description/pom.xml
+++ b/src/it/missing-index-and-description/pom.xml
@@ -14,6 +14,6 @@
     <name>MyNewPlugin</name>
     <properties>
         <jenkins.version>2.249.1</jenkins.version>
-        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+        <hpi-plugin.version>3.29-SNAPSHOT</hpi-plugin.version>
     </properties>
 </project>

--- a/src/it/missing-index-and-description/pom.xml
+++ b/src/it/missing-index-and-description/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.tools.hpi.its</groupId>
-    <artifactId>missing-index</artifactId>
+    <artifactId>missing-index-and-description</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>MyNewPlugin</name>

--- a/src/it/missing-index-and-description/src/main/java/org/jenkinsci/tools/hpi/its/X.java
+++ b/src/it/missing-index-and-description/src/main/java/org/jenkinsci/tools/hpi/its/X.java
@@ -1,0 +1,2 @@
+package org.jenkinsci.tools.hpi.its;
+public class X {}

--- a/src/it/missing-index-and-description/verify.groovy
+++ b/src/it/missing-index-and-description/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains("src/main/resources/index.jelly does not exist. A default one will be created using the description of the pom.xml");
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Create src/main/resources/index.jelly:");
 
 return true;

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -12,7 +12,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>MyNewPlugin</name>
-    <description>Deprecated spot for plugin "description" with special chars.</description>
+    <description>Deprecated spot for plugin "description" with &lt;4 special chars.</description>
     <properties>
         <jenkins.version>2.249.1</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -12,7 +12,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>MyNewPlugin</name>
-    <description>Deprecated spot for plugin description.</description>
+    <description>Deprecated spot for plugin "description" with special chars.</description>
     <properties>
         <jenkins.version>2.249.1</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>

--- a/src/it/missing-index/verify.groovy
+++ b/src/it/missing-index/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains("create src/main/resources/index.jelly:");
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Create src/main/resources/index.jelly:");
 
 return true;

--- a/src/it/missing-index/verify.groovy
+++ b/src/it/missing-index/verify.groovy
@@ -18,7 +18,8 @@
  */
 
 assert new File(basedir, 'build.log').getText('UTF-8').contains("A default one will be created using the description of the pom.xml");
-assert new File(basedir, "target/classes/index.jelly").getText('UTF-8') == """<?jelly escape-by-default='true'?>
+assert new File(basedir, "target/classes/index.jelly").getText('UTF-8') == """<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
 <div>
 Deprecated spot for plugin &quot;description&quot; with &lt;4 special chars.
 </div>"""

--- a/src/it/missing-index/verify.groovy
+++ b/src/it/missing-index/verify.groovy
@@ -18,5 +18,9 @@
  */
 
 assert new File(basedir, 'build.log').getText('UTF-8').contains("A default one will be created using the description of the pom.xml");
+assert new File(basedir, "target/classes/index.jelly").getText('UTF-8') == """<?jelly escape-by-default='true'?>
+<div>
+Deprecated spot for plugin &quot;description&quot; with &lt;4 special chars.
+</div>"""
 
 return true;

--- a/src/it/missing-index/verify.groovy
+++ b/src/it/missing-index/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains("src/main/resources/index.jelly does not exist. A default one will be created using the description of the pom.xml");
+assert new File(basedir, 'build.log').getText('UTF-8').contains("A default one will be created using the description of the pom.xml");
 
 return true;

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -149,7 +149,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                          final OutputStreamWriter indexJellyWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
                         indexJellyWriter.write("<?jelly escape-by-default='true'?>\n" +
                                 "<div>\n" +
-                                StringEscapeUtils.escapeHtml(projectDescription) + "\n" +
+                                StringEscapeUtils.escapeXml(projectDescription) + "\n" +
                                 "</div>");
                         indexJellyWriter.flush();
                     }
@@ -157,7 +157,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                     throw new MojoFailureException("Missing " + indexJelly + ". Create src/main/resources/index.jelly:\n" +
                             "<?jelly escape-by-default='true'?>\n" +
                             "<div>\n" +
-                            "    The description here...\n" +
+                            "    The description here…\n" +
                             "</div>");
                 }
             }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -147,7 +147,8 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                     getLog().warn("src/main/resources/index.jelly does not exist. A default one will be created using the description of the pom.xml");
                     try (final FileOutputStream fos = new FileOutputStream(indexJelly);
                          final OutputStreamWriter indexJellyWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-                        indexJellyWriter.write("<?jelly escape-by-default='true'?>\n" +
+                        indexJellyWriter.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                "<?jelly escape-by-default='true'?>\n" +
                                 "<div>\n" +
                                 StringEscapeUtils.escapeXml(projectDescription) + "\n" +
                                 "</div>");

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -147,7 +147,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                     getLog().warn("src/main/resources/index.jelly does not exist. A default one will be created using the description of the pom.xml");
                     try (final FileOutputStream fos = new FileOutputStream(indexJelly);
                          final OutputStreamWriter indexJellyWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-                        indexJellyWriter.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        indexJellyWriter.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                 "<?jelly escape-by-default='true'?>\n" +
                                 "<div>\n" +
                                 StringEscapeUtils.escapeXml(projectDescription) + "\n" +

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -22,6 +22,8 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
@@ -140,13 +142,14 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
             jarArchiver.addConfiguredManifest(manifest);
             File indexJelly = new File(getClassesDirectory(), "index.jelly");
             if (!indexJelly.isFile()) {
-                if (getProjectDescription() != null) {
+                final String projectDescription = getProjectDescription();
+                if (projectDescription != null) {
                     getLog().warn("src/main/resources/index.jelly does not exist. A default one will be created using the description of the pom.xml");
                     try (final FileOutputStream fos = new FileOutputStream(indexJelly);
                          final OutputStreamWriter indexJellyWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
                         indexJellyWriter.write("<?jelly escape-by-default='true'?>\n" +
                                 "<div>\n" +
-                                project.getDescription() + "\n" +
+                                StringEscapeUtils.escapeXml(projectDescription) + "\n" +
                                 "</div>");
                         indexJellyWriter.flush();
                     }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -149,7 +149,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                          final OutputStreamWriter indexJellyWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
                         indexJellyWriter.write("<?jelly escape-by-default='true'?>\n" +
                                 "<div>\n" +
-                                StringEscapeUtils.escapeXml(projectDescription) + "\n" +
+                                StringEscapeUtils.escapeHtml(projectDescription) + "\n" +
                                 "</div>");
                         indexJellyWriter.flush();
                     }
@@ -157,7 +157,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
                     throw new MojoFailureException("Missing " + indexJelly + ". Create src/main/resources/index.jelly:\n" +
                             "<?jelly escape-by-default='true'?>\n" +
                             "<div>\n" +
-                            "    The description here…\n" +
+                            "    The description here...\n" +
                             "</div>");
                 }
             }


### PR DESCRIPTION
Signed-off-by: Thierry Wasylczenko <twasyl@users.noreply.github.com>

<!-- Please describe your pull request here. -->
Currently if there is no `src/main/resources/index.jelly` file in the Jenkins plugin sources, `mvn hpi:run` will fail the build indicating the file must be created using the POM's `<description>`. This behaviour has been introduced in #302. As I like to enforce the creation of `index.jelly`, the current approach:
 - assumes there is a `<description>` in the POM
 - lead to think you have to delete the `<description>` from your POM

IMO this could be improved for plugins author's UX. If the description is present but the the file is not, I assume the author:
- doesn't need to create a file when it's content is predictive (because we have the description)
- doesn't want the content of `index.jelly` to be different from the description

This PR aims to provide the following behaviours:
- In case the `index.jelly` file doesn't exist and the description is provided, create the file under `target/classes` and log a warning
- In case the `index.jelly` file doesn't exist and the description **is not** provided, then throw an error to enforce the creation of the file by the author
- In case the `index.jelly` file is provided, use it

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
