### PR TITLE
[JEP-230] Noting deprecation of `jenkins-module` packaging

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -41,7 +41,7 @@
       </configuration>
     </component>
 
-    <!-- Jenkins module -->
+    <!-- Jenkins module (no longer used in official components as of https://jenkins.io/jep/230) -->
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
       <role-hint>jm</role-hint>


### PR DESCRIPTION
Some cleanup. See https://github.com/jenkinsci/jep/pull/391.