### PR TITLE
Ignore self in upper bounds analysis

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -211,7 +211,8 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                     }
                     RequireUpperBoundDepsVisitor visitor = new RequireUpperBoundDepsVisitor();
                     node.accept(visitor);
-                    Map<String, String> upperBounds = visitor.upperBounds(upperBoundsExcludes);
+                    String self = String.format("%s:%s", shadow.getGroupId(), shadow.getArtifactId());
+                    Map<String, String> upperBounds = visitor.upperBounds(upperBoundsExcludes, self);
 
                     if (upperBounds.isEmpty()) {
                         converged = true;
@@ -664,7 +665,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
         }
 
         // added for TestDependencyMojo in place of getConflicts/containsConflicts
-        public Map<String, String> upperBounds(List<String> upperBoundsExcludes) {
+        public Map<String, String> upperBounds(List<String> upperBoundsExcludes, String self) {
             Map<String, String> r = new HashMap<>();
             for (List<DependencyNodeHopCountPair> pairs : keyToPairsMap.values()) {
                 DependencyNodeHopCountPair resolvedPair = pairs.get(0);
@@ -683,7 +684,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                     if (resolvedVersion.compareTo(version) < 0) {
                         Artifact artifact = resolvedPair.node.getArtifact();
                         String key = toKey(artifact);
-                        if (!r.containsKey(key) || new ComparableVersion(version.toString()).compareTo(new ComparableVersion(r.get(key))) > 1) {
+                        if (!key.equals(self) && (!r.containsKey(key) || new ComparableVersion(version.toString()).compareTo(new ComparableVersion(r.get(key))) > 1)) {
                             if (upperBoundsExcludes.contains(key)) {
                                 getLog().info( "Ignoring requireUpperBoundDeps in " + key);
                             } else {


### PR DESCRIPTION
A bug in #336 noticed when doing further testing: we were generating upper bounds overrides of the plugin under test (!), which led to the upper bounds analysis never iterating to convergence. Needless to say we should never be trying to add ourselves to our own dependency management section.