### PR TITLE
Append to existing properties rather than clobbering them

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -375,9 +375,24 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 getLog().debug(String.format("Replacing POM-defined classpath elements %s with %s", classpathDependencyExcludes, additionalClasspathElements));
             }
             // cf. http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html
-            properties.setProperty("maven.test.additionalClasspath", String.join(",", additionalClasspathElements));
-            properties.setProperty("maven.test.dependency.excludes", String.join(",", classpathDependencyExcludes));
+            appendEntries("maven.test.additionalClasspath", additionalClasspathElements, properties);
+            appendEntries("maven.test.dependency.excludes", classpathDependencyExcludes, properties);
         }
+    }
+
+    private static void appendEntries(String property, Collection<String> additions, Properties properties) {
+        String existing = properties.getProperty(property);
+        List<String> newEntries = new ArrayList<>();
+        if (existing != null && !existing.isEmpty()) {
+            for (String entry : existing.split(",")) {
+                entry = entry.trim();
+                if (!entry.isEmpty()) {
+                    newEntries.add(entry);
+                }
+            }
+        }
+        newEntries.addAll(additions);
+        properties.setProperty(property, String.join(",", newEntries));
     }
 
     /**


### PR DESCRIPTION
Noticed when testing with the `variant` plugin, which has its own entry for `maven.test.dependency.excludes` for test purposes. Before this PR we were clobbering the existing value of this property; after this PR, we append to it rather than clobbering it. I tested that this gets the `variant` plugin's tests working again (at least after they're converted to use the `maven.test.dependency.excludes` rather than setting the value directly).