### PR TITLE
Relax release check

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -169,7 +169,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
         } else {
             // Under no circumstances should this code ever be executed when performing a release.
             for (String goal : session.getGoals()) {
-                if (goal.contains("install") || goal.contains("deploy")) {
+                if (goal.contains("deploy")) {
                     throw new MojoExecutionException("Cannot override dependencies when doing a release");
                 }
             }


### PR DESCRIPTION
This gets in the way of PCT's `install` goal specified in this code path:

https://github.com/jenkinsci/plugin-compat-tester/blob/f035412416dd448b85b472c65202ac6a6b7c50ef/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java#L124-L130