### PR TITLE
re-allow animal sniffer

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -44,9 +44,6 @@ public class InitializeMojo extends AbstractJenkinsMojo {
             setProperty("maven.compiler.release", Integer.toString(javaVersion.toReleaseVersion()));
             setProperty("maven.compiler.testRelease", Integer.toString(javaVersion.toReleaseVersion()));
 
-            // "release" serves the same purpose as Animal Sniffer.
-            setProperty("animal.sniffer.skip", "true");
-
             /*
              * While it does not hurt to have these set to the Java specification version, it is also not needed when
              * "release" is in use.


### PR DESCRIPTION
`maven-hpi-plugin` setting `animal.sniffer.skip` to `true` unconditionally may be exceeding its responsibilities, and making difficult (if not impossible) to actually run animal sniffer in plugins: overriding `animal.sniffer.skip` in a plugin to make it `false` is not taking any effect, it’s still skipped.
Removing this here and only keeping https://github.com/jenkinsci/plugin-pom/blob/283a7c29b3f08b8ffa1ebd51d7d8f9d520447995/pom.xml#L961 has no negative affect on plugins without signature checking, using either java 8 or 11, and allows to enable animal sniffer in plugins to their discretion.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
