### PR TITLE
`resolve-test-dependencies` should not add deps unrelated to the model by default

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -594,10 +594,10 @@ public class TestDependencyMojo extends AbstractHpiMojo {
 
         if (overrideWarAdditions) {
             /*
-            * If a bundled plugin was added that is neither in the model nor the transitive dependency
-            * chain, add a test-scoped direct dependency to the model. This is necessary in order for
-            * us to be able to correctly populate target/test-dependencies/ later on.
-            */
+             * If a bundled plugin was added that is neither in the model nor the transitive dependency
+             * chain, add a test-scoped direct dependency to the model. This is necessary in order for
+             * us to be able to correctly populate target/test-dependencies/ later on.
+             */
             Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
             unappliedBundledPlugins.removeAll(appliedBundledPlugins);
             for (String key : unappliedBundledPlugins) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -100,8 +100,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
     /**
      * Path to a Jenkins WAR file with bundled plugins to apply during testing. Dependencies already
      * present in the project model or their transitive dependencies will be updated to the versions
-     * in the WAR. Dependencies not already present in the project model will be added to the
-     * project model. May be combined with {@code overrideVersions} so long as the results do not
+     * in the WAR. May be combined with {@code overrideVersions} so long as the results do not
      * conflict. The version of the WAR must be identical to {@code jenkins.version}.
      */
     @Parameter(property = "overrideWar")
@@ -581,30 +580,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             } else {
                 throw new MojoExecutionException("Failed to apply the following overrides: " + unappliedOverrides);
             }
-        }
-
-        /*
-         * If a bundled plugin was added that is neither in the model nor the transitive dependency
-         * chain, add a test-scoped direct dependency to the model. This is necessary in order for
-         * us to be able to correctly populate target/test-dependencies/ later on.
-         */
-        Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
-        unappliedBundledPlugins.removeAll(appliedBundledPlugins);
-        for (String key : unappliedBundledPlugins) {
-            String[] groupArt = key.split(":");
-            String groupId = groupArt[0];
-            String artifactId = groupArt[1];
-            String version = bundledPlugins.get(key);
-            Dependency dependency = new Dependency();
-            dependency.setGroupId(groupId);
-            dependency.setArtifactId(artifactId);
-            dependency.setVersion(version);
-            dependency.setScope(Artifact.SCOPE_TEST);
-            if (dependency.getGroupId().equals(project.getGroupId()) && dependency.getArtifactId().equals(project.getArtifactId())) {
-                throw new MojoExecutionException("Cannot add self as test-scoped dependency");
-            }
-            log.info(String.format("Adding test-scoped direct dependency %s:%s", key, version));
-            project.getDependencies().add(dependency);
         }
 
         log.debug("adjusted dependencies: " + project.getDependencies());

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -196,10 +196,11 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             if (useUpperBounds) {
                 boolean converged = false;
                 int i = 0;
+                Map<String, String> upperBounds = null;
 
                 while (!converged) {
                     if (i++ > 10) {
-                        throw new MojoExecutionException("Failed to iterate to convergence during upper bounds analysis");
+                        throw new MojoExecutionException("Failed to iterate to convergence during upper bounds analysis: " + upperBounds);
                     }
 
                     /*
@@ -219,7 +220,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                     RequireUpperBoundDepsVisitor visitor = new RequireUpperBoundDepsVisitor();
                     node.accept(visitor);
                     String self = String.format("%s:%s", shadow.getGroupId(), shadow.getArtifactId());
-                    Map<String, String> upperBounds = visitor.upperBounds(upperBoundsExcludes, self);
+                    upperBounds = visitor.upperBounds(upperBoundsExcludes, self);
 
                     if (upperBounds.isEmpty()) {
                         converged = true;
@@ -706,6 +707,10 @@ public class TestDependencyMojo extends AbstractHpiMojo {
 
                 for (DependencyNodeHopCountPair pair : pairs) {
                     ArtifactVersion version = pair.extractArtifactVersion(true);
+                    if (version.toString().equals("[0]")) {
+                        // javax.servlet:servlet-api fake entry
+                        continue;
+                    }
                     if (resolvedVersion.compareTo(version) < 0) {
                         Artifact artifact = resolvedPair.node.getArtifact();
                         String key = toKey(artifact);

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -492,7 +492,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             Log log)
             throws MojoExecutionException {
         Set<String> appliedOverrides = new HashSet<>();
-        Set<String> appliedBundledPlugins = new HashSet<>();
 
         // Update existing dependency entries in the model.
         for (Dependency dependency : project.getDependencies()) {
@@ -500,9 +499,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             if (updateDependency(dependency, overrides, "direct dependency", log)) {
                 appliedOverrides.add(key);
             }
-            if (updateDependency(dependency, bundledPlugins, "direct dependency", log)) {
-                appliedBundledPlugins.add(key);
-            }
+            updateDependency(dependency, bundledPlugins, "direct dependency", log);
         }
 
         // Update existing dependency management entries in the model.
@@ -512,9 +509,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 if (updateDependency(dependency, overrides, "dependency management entry", log)) {
                     appliedOverrides.add(key);
                 }
-                if (updateDependency(dependency, bundledPlugins, "dependency management entry", log)) {
-                    appliedBundledPlugins.add(key);
-                }
+                updateDependency(dependency, bundledPlugins, "dependency management entry", log);
             }
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -707,10 +707,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
 
                 for (DependencyNodeHopCountPair pair : pairs) {
                     ArtifactVersion version = pair.extractArtifactVersion(true);
-                    if (version.toString().equals("[0]")) {
-                        // javax.servlet:servlet-api fake entry
-                        continue;
-                    }
                     if (resolvedVersion.compareTo(version) < 0) {
                         Artifact artifact = resolvedPair.node.getArtifact();
                         String key = toKey(artifact);


### PR DESCRIPTION
Trying to figure out what https://github.com/jenkinsci/maven-hpi-plugin/pull/336#discussion_r860922529 really meant.

(`overrideWar` does not appear to have any IT coverage, so this is just a placeholder to be tested in the context of `bom`.)
