### PR TITLE
Simplify semantics

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -492,7 +492,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             Log log)
             throws MojoExecutionException {
         Set<String> appliedOverrides = new HashSet<>();
-        Set<String> appliedBundledPlugins = new HashSet<>();
 
         // Update existing dependency entries in the model.
         for (Dependency dependency : project.getDependencies()) {
@@ -500,9 +499,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             if (updateDependency(dependency, overrides, "direct dependency", log)) {
                 appliedOverrides.add(key);
             }
-            if (updateDependency(dependency, bundledPlugins, "direct dependency", log)) {
-                appliedBundledPlugins.add(key);
-            }
+            updateDependency(dependency, bundledPlugins, "direct dependency", log);
         }
 
         // Update existing dependency management entries in the model.
@@ -512,9 +509,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 if (updateDependency(dependency, overrides, "dependency management entry", log)) {
                     appliedOverrides.add(key);
                 }
-                if (updateDependency(dependency, bundledPlugins, "dependency management entry", log)) {
-                    appliedBundledPlugins.add(key);
-                }
+                updateDependency(dependency, bundledPlugins, "dependency management entry", log);
             }
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -150,7 +150,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 overrides.remove(override);
             } else {
                 throw new MojoExecutionException(String.format(
-                        "Failed to override %s: conflict between %s in overrideVersions and %s in overrideWar",
+                        "Failed to override %s: conflict between %s in overrideVersions and %s in jth.jenkins-war.path",
                         override, overrides.get(override), bundledPlugins.get(override)));
             }
         }
@@ -455,9 +455,9 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 jenkinsVersion = project.getProperties().getProperty("jenkins.version");
             }
             if (jenkinsVersion == null) {
-                throw new MojoExecutionException("jenkins.version must be set when using overrideWar");
+                throw new MojoExecutionException("jenkins.version must be set when using jth.jenkins-war.path");
             } else if (!jenkinsVersion.equals(coreVersion)) {
-                throw new MojoExecutionException("jenkins.version must match the version specified by overrideWar: " + coreVersion);
+                throw new MojoExecutionException("jenkins.version must match the version specified by jth.jenkins-war.path: " + coreVersion);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to scan " + war, e);

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -100,11 +100,10 @@ public class TestDependencyMojo extends AbstractHpiMojo {
     /**
      * Path to a Jenkins WAR file with bundled plugins to apply during testing. Dependencies already
      * present in the project model or their transitive dependencies will be updated to the versions
-     * in the WAR. Dependencies not already present in the project model will be added to the
-     * project model. May be combined with {@code overrideVersions} so long as the results do not
+     * in the WAR. May be combined with {@code overrideVersions} so long as the results do not
      * conflict. The version of the WAR must be identical to {@code jenkins.version}.
      */
-    @Parameter(property = "overrideWar")
+    @Parameter(property = "jth.jenkins-war.path")
     private File overrideWar;
 
     /**
@@ -581,30 +580,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             } else {
                 throw new MojoExecutionException("Failed to apply the following overrides: " + unappliedOverrides);
             }
-        }
-
-        /*
-         * If a bundled plugin was added that is neither in the model nor the transitive dependency
-         * chain, add a test-scoped direct dependency to the model. This is necessary in order for
-         * us to be able to correctly populate target/test-dependencies/ later on.
-         */
-        Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
-        unappliedBundledPlugins.removeAll(appliedBundledPlugins);
-        for (String key : unappliedBundledPlugins) {
-            String[] groupArt = key.split(":");
-            String groupId = groupArt[0];
-            String artifactId = groupArt[1];
-            String version = bundledPlugins.get(key);
-            Dependency dependency = new Dependency();
-            dependency.setGroupId(groupId);
-            dependency.setArtifactId(artifactId);
-            dependency.setVersion(version);
-            dependency.setScope(Artifact.SCOPE_TEST);
-            if (dependency.getGroupId().equals(project.getGroupId()) && dependency.getArtifactId().equals(project.getArtifactId())) {
-                throw new MojoExecutionException("Cannot add self as test-scoped dependency");
-            }
-            log.info(String.format("Adding test-scoped direct dependency %s:%s", key, version));
-            project.getDependencies().add(dependency);
         }
 
         log.debug("adjusted dependencies: " + project.getDependencies());


### PR DESCRIPTION
If I am understanding #373 then there is no real use case where one would ever want to set `overrideWar` but not also `jth.jenkins-war.path`, so let's just consume the `jth.jenkins-war.path` property directly the same way the test harness does instead of forcing the user to specify two options both pointing to the same file. With that semantic in place, there is no need to add dependencies not already present in the project model to the project model, since the use case of testing plugin-to-plugin interaction of "long tail" (unrelated) plugins is handled by setting `jth.jenkins-war.path`, and such a use case probably doesn't exist for someone who is setting `overrideVersions` but not `jth.jenkins-war.path`.