### PR TITLE
Slightly simplify semantics

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -98,14 +98,15 @@ public class TestDependencyMojo extends AbstractHpiMojo {
     private List<String> overrideVersions;
 
     /**
-     * Path to a Jenkins WAR file with bundled plugins to apply during testing. Dependencies already
-     * present in the project model or their transitive dependencies will be updated to the versions
-     * in the WAR. Dependencies not already present in the project model will be added to the
-     * project model. May be combined with {@code overrideVersions} so long as the results do not
-     * conflict. The version of the WAR must be identical to {@code jenkins.version}.
+     * If true, apply overrides from a Jenkins WAR file (specified by {@code jth.jenkins-war.path})
+     * with bundled plugins during testing. Dependencies already present in the project model or
+     * their transitive dependencies will be updated to the versions in the WAR. May be combined
+     * with {@code overrideVersions} so long as the results do not conflict. The version of the WAR
+     * must be identical to {@code jenkins.version}. {@code jt.jenkins-war.patch} must be provided
+     * when using this option.
      */
     @Parameter(property = "overrideWar")
-    private File overrideWar;
+    private boolean overrideWar;
 
     /**
      * Whether to update all transitive dependencies to the upper bounds. Effectively causes the
@@ -133,9 +134,13 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             throw new MojoExecutionException("Cannot override self");
         }
 
-        Map<String, String> bundledPlugins = overrideWar != null ? scanWar(overrideWar, session, project) : Collections.emptyMap();
+        String jthJenkinsWarPath = System.getProperty("jth.jenkins-war.path");
+        if (overrideWar && jthJenkinsWarPath == null) {
+            throw new MojoExecutionException("jth.jenkins-war.path must be set when using overrideWar");
+        }
+        Map<String, String> bundledPlugins = overrideWar ? scanWar(new File(jthJenkinsWarPath), session, project) : Collections.emptyMap();
         if (!bundledPlugins.isEmpty()) {
-            getLog().info(String.format("Scanned contents of %s with %d bundled plugins", overrideWar, bundledPlugins.size()));
+            getLog().info(String.format("Scanned contents of %s with %d bundled plugins", jthJenkinsWarPath, bundledPlugins.size()));
         }
 
         // Deal with conflicts in user-provided input.
@@ -151,7 +156,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 overrides.remove(override);
             } else {
                 throw new MojoExecutionException(String.format(
-                        "Failed to override %s: conflict between %s in overrideVersions and %s in overrideWar",
+                        "Failed to override %s: conflict between %s in overrideVersions and %s in jth.jenkins-war.path when using overrideWar",
                         override, overrides.get(override), bundledPlugins.get(override)));
             }
         }
@@ -164,7 +169,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
         Map<String, String> deletions = new HashMap<>();
         Map<String, String> updates = new HashMap<>();
 
-        if (overrides.isEmpty() && overrideWar == null) {
+        if (overrides.isEmpty() && !overrideWar) {
             effectiveArtifacts = getProjectArtfacts();
         } else {
             // Under no circumstances should this code ever be executed when performing a release.
@@ -458,7 +463,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             if (jenkinsVersion == null) {
                 throw new MojoExecutionException("jenkins.version must be set when using overrideWar");
             } else if (!jenkinsVersion.equals(coreVersion)) {
-                throw new MojoExecutionException("jenkins.version must match the version specified by overrideWar: " + coreVersion);
+                throw new MojoExecutionException("jenkins.version must match the version specified by jth.jenkins-war.path when using overrideWar: " + coreVersion);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to scan " + war, e);
@@ -493,7 +498,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             Log log)
             throws MojoExecutionException {
         Set<String> appliedOverrides = new HashSet<>();
-        Set<String> appliedBundledPlugins = new HashSet<>();
 
         // Update existing dependency entries in the model.
         for (Dependency dependency : project.getDependencies()) {
@@ -501,9 +505,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             if (updateDependency(dependency, overrides, "direct dependency", log)) {
                 appliedOverrides.add(key);
             }
-            if (updateDependency(dependency, bundledPlugins, "direct dependency", log)) {
-                appliedBundledPlugins.add(key);
-            }
+            updateDependency(dependency, bundledPlugins, "direct dependency", log);
         }
 
         // Update existing dependency management entries in the model.
@@ -513,9 +515,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 if (updateDependency(dependency, overrides, "dependency management entry", log)) {
                     appliedOverrides.add(key);
                 }
-                if (updateDependency(dependency, bundledPlugins, "dependency management entry", log)) {
-                    appliedBundledPlugins.add(key);
-                }
+                updateDependency(dependency, bundledPlugins, "dependency management entry", log);
             }
         }
 
@@ -581,30 +581,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             } else {
                 throw new MojoExecutionException("Failed to apply the following overrides: " + unappliedOverrides);
             }
-        }
-
-        /*
-         * If a bundled plugin was added that is neither in the model nor the transitive dependency
-         * chain, add a test-scoped direct dependency to the model. This is necessary in order for
-         * us to be able to correctly populate target/test-dependencies/ later on.
-         */
-        Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
-        unappliedBundledPlugins.removeAll(appliedBundledPlugins);
-        for (String key : unappliedBundledPlugins) {
-            String[] groupArt = key.split(":");
-            String groupId = groupArt[0];
-            String artifactId = groupArt[1];
-            String version = bundledPlugins.get(key);
-            Dependency dependency = new Dependency();
-            dependency.setGroupId(groupId);
-            dependency.setArtifactId(artifactId);
-            dependency.setVersion(version);
-            dependency.setScope(Artifact.SCOPE_TEST);
-            if (dependency.getGroupId().equals(project.getGroupId()) && dependency.getArtifactId().equals(project.getArtifactId())) {
-                throw new MojoExecutionException("Cannot add self as test-scoped dependency");
-            }
-            log.info(String.format("Adding test-scoped direct dependency %s:%s", key, version));
-            project.getDependencies().add(dependency);
         }
 
         log.debug("adjusted dependencies: " + project.getDependencies());


### PR DESCRIPTION
A middle ground between what I feel are the overly conservative semantics from #373 and the perhaps too risky semantics of #375. No risk to anyone who is passing `jth.jenkins-war.path` but doesn't want any change in behavior or to be forced to pass `jenkins.version`. For those who are passing `jth.jenkins-war.path` and want an override, they now would pass `overrideWar=true`, which cues us to pick up the WAR from `jth.jenkins-war.path`. In that case, the use of `jth.jenkins-war.path` satisfies the use case of testing interaction between the "long tail" of plugins unrelated to the main plugin being tested. That use case doesn't exist for someone who is just using `overrideVersions`, but that consumer probably isn't passing in `overrideWar` anyway.