### PR TITLE
Indicate `classifier` if set in `updateDependency` message

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -636,7 +636,8 @@ public class TestDependencyMojo extends AbstractHpiMojo {
         String key = toKey(dependency);
         String overrideVersion = overrides.get(key);
         if (overrideVersion != null) {
-            log.info(String.format("Updating %s %s from %s to %s", type, key, dependency.getVersion(), overrideVersion));
+            String classifier = dependency.getClassifier();
+            log.info(String.format("Updating %s %s%s from %s to %s", type, key, classifier != null ? ":" + classifier : "", dependency.getVersion(), overrideVersion));
             dependency.setVersion(overrideVersion);
             return true;
         }


### PR DESCRIPTION
```
[INFO] Updating dependency management entry org.jenkins-ci.plugins:git from 4.10.0 to 4.11.3
[INFO] Updating dependency management entry org.jenkins-ci.plugins:git from 4.10.0 to 4.11.3
```

is confusing.

Amends #336.