### PR TITLE
Add a `dependencyManagement` section if missing

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -579,12 +579,12 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                         throw new MojoExecutionException("Cannot add self to dependency management section");
                     }
                     DependencyManagement dm = project.getDependencyManagement();
-                    if (dm != null) {
-                        log.info(String.format("Adding dependency management entry %s:%s", key, dependency.getVersion()));
-                        dm.addDependency(dependency);
-                    } else {
-                        throw new MojoExecutionException(String.format("Failed to add dependency management entry %s:%s because the project does not have a dependency management section", key, overrides.get(key)));
+                    if (dm == null) {
+                        dm = new DependencyManagement();
+                        project.getModel().setDependencyManagement(dm);
                     }
+                    log.info(String.format("Adding dependency management entry %s:%s", key, dependency.getVersion()));
+                    dm.addDependency(dependency);
                     overrideAdditions.add(key);
                 }
             } else {


### PR DESCRIPTION
Appears to be necessary to run PCT on `warnings-ng` at least in the CloudBees configuration. (Not clear if https://github.com/jenkinsci/bom/pull/1384 even got that far.)

Amends #336.