### PR TITLE
Add new test for older plugin parent POM

### DIFF
--- a/src/it/parent-4-40/invoker.properties
+++ b/src/it/parent-4-40/invoker.properties
@@ -1,0 +1,3 @@
+# install, not verify, because we want to check the artifact as we would be about to deploy it
+# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
+invoker.goals=-ntp -Pjenkins-release -Drelease.skipTests=false clean install hpi:run

--- a/src/it/parent-4-40/pom.xml
+++ b/src/it/parent-4-40/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.40</version>
+        <relativePath />
+    </parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>parent-4-40</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>2.361.4</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+        <enforcer.skip>true</enforcer.skip>
+        <no-test-jar>false</no-test-jar>
+    </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>324.va_f5d6774f3a_d</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/parent-4-40/src/main/java/test/JustTesting.java
+++ b/src/it/parent-4-40/src/main/java/test/JustTesting.java
@@ -1,0 +1,24 @@
+package test;
+
+import hudson.Main;
+import hudson.init.Initializer;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
+import jenkins.util.Timer;
+
+public class JustTesting {
+
+    private JustTesting() {}
+
+    @Initializer
+    public static void shutDown() {
+        if (Main.isUnitTest) {
+            return;
+        }
+        Timer.get().schedule(() -> {
+            Jenkins.getInstance().doSafeExit(null);
+            return null;
+        }, 15, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/it/parent-4-40/src/main/java/test/SampleRootAction.java
+++ b/src/it/parent-4-40/src/main/java/test/SampleRootAction.java
@@ -1,0 +1,26 @@
+package test;
+
+import hudson.Extension;
+import hudson.model.InvisibleAction;
+import hudson.model.RootAction;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+
+@Extension
+public class SampleRootAction implements RootAction {
+    @Override
+    public String getUrlName() {
+        return "sample";
+    }
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+    public HttpResponse doIndex() {
+        return HttpResponses.plainText("sample served");
+    }
+}

--- a/src/it/parent-4-40/src/main/resources/index.jelly
+++ b/src/it/parent-4-40/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/parent-4-40/src/test/java/test/SampleRootActionTest.java
+++ b/src/it/parent-4-40/src/test/java/test/SampleRootActionTest.java
@@ -1,0 +1,20 @@
+package test;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SampleRootActionTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void smokes() throws Exception {
+        assertEquals(IOUtils.toString(SampleRootActionTest.class.getResource("expected.txt")),
+                     r.createWebClient().goTo("sample", "text/plain").getWebResponse().getContentAsString().trim());
+    }
+
+}

--- a/src/it/parent-4-40/src/test/resources/test/expected.txt
+++ b/src/it/parent-4-40/src/test/resources/test/expected.txt
@@ -1,0 +1,1 @@
+sample served

--- a/src/it/parent-4-40/verify.groovy
+++ b/src/it/parent-4-40/verify.groovy
@@ -1,0 +1,67 @@
+import java.util.jar.*
+
+assert new File(basedir, 'target/parent-4-40.hpi').exists()
+assert new File(basedir, 'target/parent-4-40.jar').exists()
+
+File installed = new File(basedir, '../../local-repo/org/jenkins-ci/tools/hpi/its/parent-4-40/1.0-SNAPSHOT/')
+assert installed.directory
+
+def checkArtifact(File installed, String artifact, List<String> expectedEntries, List<String> unexpectedEntries, Map<String,String> expectedManifestEntries) {
+    File f = new File(installed, artifact)
+    assert f.file
+    JarFile j = new JarFile(f)
+    try {
+        expectedEntries.each {entry -> assert j.getEntry(entry) != null : "no ${entry} in ${f}"}
+        unexpectedEntries.each {entry -> assert j.getEntry(entry) == null : "unwanted ${entry} in ${f}"}
+        Attributes attr = j.manifest.mainAttributes
+        expectedManifestEntries.each {header, value -> assert attr.getValue(header) == value}
+    } finally {
+        j.close()
+    }
+}
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT.hpi',
+    // TODO could also check src/main/webapp/images/32x32/foo.png → images/32x32/foo.png
+    ['WEB-INF/lib/parent-4-40.jar'],
+    // TODO still some problems with unwanted transitive JAR dependencies creeping in, e.g. WEB-INF/lib/jboss-marshalling-1.4.9.Final.jar in workflow-multibranch.hpi, or all kinds of junk in parameterized-trigger.hpi
+    ['test/SampleRootAction.class', 'WEB-INF/lib/symbol-annotation-1.5.jar'],
+    ['Short-Name': 'parent-4-40', 'Group-Id': 'org.jenkins-ci.tools.hpi.its', 'Jenkins-Version': '2.361.4' /* Plugin-Version unpredictable for a snapshot */, 'Plugin-Dependencies': 'structs:324.va_f5d6774f3a_d'])
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT.jar',
+    ['META-INF/annotations/hudson.Extension', 'test/SampleRootAction.class', 'index.jelly'],
+    [],
+    ['Short-Name': 'parent-4-40'])
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT-javadoc.jar',
+    ['test/SampleRootAction.html'],
+    [],
+    [:])
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT-sources.jar',
+    ['test/SampleRootAction.java', 'index.jelly'],
+    [],
+    [:])
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT-tests.jar',
+    ['test/SampleRootActionTest.class', 'test/expected.txt'],
+    ['the.hpl', 'InjectedTest.class', 'test-dependencies/structs.hpi'],
+    [:])
+
+checkArtifact(installed, 'parent-4-40-1.0-SNAPSHOT-test-sources.jar',
+    ['test/SampleRootActionTest.java', 'test/expected.txt'],
+    [],
+    [:])
+
+// TODO check that we can access http://localhost:8080/jenkins/sample/ during hpi:run
+// (tricky since this script is called only once mvn is done)
+def text = new File(basedir, 'build.log').text
+assert text.contains('Jenkins is fully up and running') && text.contains('INFO\thudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped')
+assert new File(basedir, 'work/plugins/parent-4-40.hpl').file
+assert new File(basedir, 'work/plugins/structs.jpi').file
+
+// TODO run a copy of jenkins.war with the installed *.hpi predeployed and do a similar check
+
+return true
+
+// TODO make similar test for plugin with no-test-jar=true (the default)
+// TODO also test building with: JITPACK=true mvn -DskipTests clean install


### PR DESCRIPTION
A copy of `parent-4x` that verifies that the HPI plugin continues to work against older plugin parent POMs like 4.40.