### PR TITLE
Clean up `TestRuntimeMojo`

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -18,7 +18,8 @@
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <generate-test-sources>org.jenkins-ci.tools:maven-hpi-plugin:insert-test</generate-test-sources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile,org.jenkins-ci.tools:maven-hpi-plugin:test-hpl,org.jenkins-ci.tools:maven-hpi-plugin:resolve-test-dependencies</test-compile>
-              <test>org.jenkins-ci.tools:maven-hpi-plugin:test-runtime,org.apache.maven.plugins:maven-surefire-plugin:test</test>
+              <process-test-classes>org.jenkins-ci.tools:maven-hpi-plugin:test-runtime</process-test-classes>
+              <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
               <package>org.jenkins-ci.tools:maven-hpi-plugin:hpi</package>
               <install>org.apache.maven.plugins:maven-install-plugin:install</install>
               <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>


### PR DESCRIPTION
Removing some no-longer-necessary Java 8 logic and maybe hoping to fix jenkinsci/bom#1551 by moving the copying of the patch module to an earlier phase? To test this I ran `mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest`.