### PR TITLE
Temporarily support 2.332.x for BOM test suite

### DIFF
--- a/src/it/jenkins-version/pom.xml
+++ b/src/it/jenkins-version/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
     <name>MyNewPlugin</name>
     <properties>
-        <jenkins.version>2.360</jenkins.version>
+        <jenkins.version>2.331</jenkins.version>
         <hpi-plugin.version>@project.version@</hpi-plugin.version>
     </properties>
 </project>

--- a/src/it/jenkins-version/verify.groovy
+++ b/src/it/jenkins-version/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains('This version of maven-hpi-plugin requires Jenkins 2.361 or later')
+assert new File(basedir, 'build.log').getText('UTF-8').contains('This version of maven-hpi-plugin requires Jenkins 2.332 or later')
 
 return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -38,8 +38,8 @@ public class ValidateMojo extends AbstractJenkinsMojo {
             throw new MojoExecutionException("Java " + javaVersion + " or later is necessary to build this plugin.");
         }
 
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.361")) < 0) {
-            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.361 or later");
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.332")) < 0) {
+            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.332 or later");
         }
 
         MavenProject parent = project.getParent();


### PR DESCRIPTION
#398 (and possibly #403?) was too aggressive: while the BOM test suite does run against Java 11, it still runs against 2.332.x and 2.346.x using the latest version of the HPI plugin. Temporarily restore support for 2.332.x to accommodate this use case until BOM drops support for for 2.332 and 2.346.