### PR TITLE
JENKINS-70329: hpi:run uses wrong jpi/hpl from .jenkins-hpl-map

### DIFF
--- a/src/it/JENKINS-70329-dir-one/invoker.properties
+++ b/src/it/JENKINS-70329-dir-one/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp clean install hpi:run -Djetty.skip=true -DskipTests

--- a/src/it/JENKINS-70329-dir-one/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.53</version>
+    <relativePath />
+  </parent>
+
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>duplicate-bundle-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+  </properties>
+  
+  <modules>
+    <module>sub-module1</module>
+    <module>sub-module2</module>
+    <module>sub-module3</module>
+    <module>sub-module4</module>
+    <module>sub-module5</module>
+    <module>sub-module6</module>
+    <module>sub-module7</module>
+    <module>sub-module8</module>
+    <module>sub-module9</module>
+    <module>sub-module10</module>
+  </modules>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module1/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module1/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module1</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module1/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module1/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module10/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module10/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module10</artifactId>
+
+  <packaging>hpi</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module1</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module2</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module3</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module4</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module5</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module6</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module7</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module8</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module9</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module10/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module10/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module2/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module2</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module2/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module2/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module3/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module3/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module3</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module3/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module3/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module4/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module4/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module4</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module4/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module4/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module5/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module5/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module5</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module5/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module5/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module6/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module6/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module6</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module6/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module6/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module7/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module7/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module7</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module7/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module7/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module8/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module8/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module8</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module8/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module8/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/sub-module9/pom.xml
+++ b/src/it/JENKINS-70329-dir-one/sub-module9/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module9</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-one/sub-module9/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-one/sub-module9/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-one/verify.groovy
+++ b/src/it/JENKINS-70329-dir-one/verify.groovy
@@ -24,7 +24,7 @@ import java.nio.charset.Charset
 for (String line : FileUtils.readLines(new File(basedir, 'build.log'), Charset.defaultCharset())) {
     if (line.contains('Copying snapshot dependency Jenkins plugin')) {
         // ensure contains only JENKINS-70329-dir-one paths
-        assert line.matches('.*maven-hpi-plugin/target/its/JENKINS-70329-dir-one/sub-module[0-9]/target/test-classes/the.hpl')
+        assert line.matches('.*/target/its/JENKINS-70329-dir-one/sub-module[0-9]/target/test-classes/the.hpl')
     }
 }
 return true

--- a/src/it/JENKINS-70329-dir-one/verify.groovy
+++ b/src/it/JENKINS-70329-dir-one/verify.groovy
@@ -1,0 +1,30 @@
+import org.apache.commons.io.FileUtils
+
+import java.nio.charset.Charset
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+for (String line : FileUtils.readLines(new File(basedir, 'build.log'), Charset.defaultCharset())) {
+    if (line.contains('Copying snapshot dependency Jenkins plugin')) {
+        // ensure contains only JENKINS-70329-dir-one paths
+        assert line.matches('.*maven-hpi-plugin/target/its/JENKINS-70329-dir-one/sub-module[0-9]/target/test-classes/the.hpl')
+    }
+}
+return true

--- a/src/it/JENKINS-70329-dir-two/invoker.properties
+++ b/src/it/JENKINS-70329-dir-two/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp clean install hpi:run -Djetty.skip=true -DskipTests

--- a/src/it/JENKINS-70329-dir-two/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.53</version>
+    <relativePath />
+  </parent>
+
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>duplicate-bundle-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+  </properties>
+  
+  <modules>
+    <module>sub-module1</module>
+    <module>sub-module2</module>
+    <module>sub-module3</module>
+    <module>sub-module4</module>
+    <module>sub-module5</module>
+    <module>sub-module6</module>
+    <module>sub-module7</module>
+    <module>sub-module8</module>
+    <module>sub-module9</module>
+    <module>sub-module10</module>
+  </modules>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module1/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module1/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module1</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module1/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module1/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module10/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module10/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module10</artifactId>
+
+  <packaging>hpi</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module1</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module2</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module3</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module4</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module5</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module6</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module7</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module8</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+      <artifactId>duplicate-bundle-it-module9</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module10/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module10/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module2/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module2</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module2/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module2/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module3/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module3/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module3</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module3/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module3/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module4/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module4/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module4</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module4/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module4/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module5/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module5/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module5</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module5/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module5/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module6/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module6/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module6</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module6/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module6/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module7/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module7/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module7</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module7/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module7/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module8/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module8/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module8</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module8/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module8/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/sub-module9/pom.xml
+++ b/src/it/JENKINS-70329-dir-two/sub-module9/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>duplicate-bundle-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  
+  <artifactId>duplicate-bundle-it-module9</artifactId>
+
+  <packaging>hpi</packaging>
+</project>

--- a/src/it/JENKINS-70329-dir-two/sub-module9/src/main/resources/index.jelly
+++ b/src/it/JENKINS-70329-dir-two/sub-module9/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/JENKINS-70329-dir-two/verify.groovy
+++ b/src/it/JENKINS-70329-dir-two/verify.groovy
@@ -1,0 +1,30 @@
+import org.apache.commons.io.FileUtils
+
+import java.nio.charset.Charset
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+for (String line : FileUtils.readLines(new File(basedir, 'build.log'), Charset.defaultCharset())) {
+    if (line.contains('Copying snapshot dependency Jenkins plugin')) {
+        // ensure contains only JENKINS-70329-dir-two paths
+        assert line.matches('.*maven-hpi-plugin/target/its/JENKINS-70329-dir-two/sub-module[0-9]/target/test-classes/the.hpl')
+    }
+}
+return true

--- a/src/it/JENKINS-70329-dir-two/verify.groovy
+++ b/src/it/JENKINS-70329-dir-two/verify.groovy
@@ -24,7 +24,7 @@ import java.nio.charset.Charset
 for (String line : FileUtils.readLines(new File(basedir, 'build.log'), Charset.defaultCharset())) {
     if (line.contains('Copying snapshot dependency Jenkins plugin')) {
         // ensure contains only JENKINS-70329-dir-two paths
-        assert line.matches('.*maven-hpi-plugin/target/its/JENKINS-70329-dir-two/sub-module[0-9]/target/test-classes/the.hpl')
+        assert line.matches('.*/target/its/JENKINS-70329-dir-two/sub-module[0-9]/target/test-classes/the.hpl')
     }
 }
 return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMap.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMap.java
@@ -15,5 +15,8 @@ import java.io.IOException;
  */
 public interface PluginWorkspaceMap {
     File read(String id) throws IOException;
+    
+    File read(String id, String workspace) throws IOException;
+    
     void write(String id, File dir) throws IOException;
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
@@ -44,16 +44,26 @@ public class PluginWorkspaceMapImpl implements PluginWorkspaceMap {
     @Override
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "TODO needs triage")
     public /*@CheckForNull*/ File read(String id) throws IOException {
+        return read(id, null);
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "TODO needs triage")
+    public File read(String id, String workspace) throws IOException {
+        File matching = null;
         for (Map.Entry<Object,Object> entry : loadMap().entrySet()) {
             if (entry.getValue().equals(id)) {
                 String path = (String) entry.getKey();
                 File f = new File(path);
                 if (f.exists()) {
-                    return f;
+                    matching = f;
+                    if (workspace == null || path.startsWith(workspace)) {
+                         break;
+                    }
                 }
             }
         }
-        return null;
+        return matching;
     }
 
     @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-70329

Check if the resolved `the.hpl` from `/Users/xxx/.jenkins-hpl-map` are contained within the current maven root project.
If not, logs a WARN instead of an INFO.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
