### PR TITLE
do not try and unpack all our dependencies looking for a mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,8 +376,8 @@
         <version>${maven-plugin-tools.version}</version>
         <configuration>
           <goalPrefix>hpi</goalPrefix>
-          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-          <!-- see MNG-5346 -->
+          <extractors>java-annotations</extractors>
+          <mojoDependencies></mojoDependencies>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <configuration>
           <goalPrefix>hpi</goalPrefix>
           <extractors>java-annotations</extractors>
-          <mojoDependencies></mojoDependencies>
+          <mojoDependencies>org.eclipse.jetty:jetty-maven-plugin</mojoDependencies>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The plugins Mojos are not defined in dependencies, so do not try and unpack them looking for them

This fixes a slew of warnings when building the plugin on windows: 

```
[WARNING] Archive entry
'org/apache/maven/plugins/dependency/fromDependencies/AbstractFromDependenciesMojo.java' and existing file
'C:\workarea\source\github\jenkinsci\maven-hpi-plugin\target\maven-plugin-plugin-sources\org.apache.maven.plugins\maven-dependency-plugin\3.4.0\sources\org\apache\maven\plugins\dependency\fromDependencies\AbstractFromDependenciesMojo.java' names differ only by case. This may lead to an unexpected outcome on case-insensitive filesystems.
```

This fixes the noise spam.  really the unarchiver that is erroneously warning (the names do match just `/` is a `\`) but I could not quickly find the source of this, and this fix means we can  see any other warnings.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
