### PR TITLE
workaround MPLUGIN-449

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <aether.version>1.1.0</aether.version>
     <maven.version>3.8.7</maven.version>
-    <maven-plugin-tools.version>3.7.0</maven-plugin-tools.version>
+    <maven-plugin-tools.version>3.7.0</maven-plugin-tools.version> <!-- extra work needed when https://issues.apache.org/jira/browse/MPLUGIN-449 is fixed -->
     <plexus-containers.version>2.1.1</plexus-containers.version>
     <aether.version>1.1.0</aether.version>
   </properties>
@@ -393,6 +393,14 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <!-- TODO remove when https://issues.apache.org/jira/browse/MPLUGIN-449 is fixed -->
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>4.6.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
on windows the build would produce a large amount of warnings due to https://github.com/codehaus-plexus/plexus-archiver/issues/248 which in turn caused https://issues.apache.org/jira/browse/MPLUGIN-449

until that is fixed bump the plexus archiver dependency version on the maven-plugin-plugin so the warnings go away.


amends #420 
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
