### PR TITLE
Add windows to the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,10 @@ properties([
 def runTests(Map params = [:]) {
   return {
     def agentContainerLabel = 'maven-' + params['jdk']
-    boolean publishing = params['jdk'] == 11
+    if (params['platform'] == 'windows') {
+      agentContainerLabel += '-windows'
+    }
+    boolean publishing = params['jdk'] == 11 && params['platform'] == 'linux'
     node(agentContainerLabel) {
       timeout(time: 1, unit: 'HOURS') {
         def stageIdentifier = params['platform'] + '-' + params['jdk']
@@ -37,6 +40,7 @@ def runTests(Map params = [:]) {
 }
 
 parallel(
+    'windows-11': runTests(platform: 'windows', jdk: 11),
     'linux-11': runTests(platform: 'linux', jdk: 11),
     'linux-17': runTests(platform: 'linux', jdk: 17)
 )


### PR DESCRIPTION
Adding windows to the mix as

1. we have developers consuming hpi plugin on windows so we want to run the ITs on windows to ensure we do not break windows plugin development
2. we have developers contributing to this plugin using windows and have observed some windows specific issues in the plugin build.

[build log](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fmaven-hpi-plugin/detail/PR-422/1/pipeline/72#step-85-log-67) demonstrates that #420 was not complete.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
