### PR TITLE
Handle `IllegalArgumentException` from `Properties.load`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
@@ -36,6 +36,8 @@ public class PluginWorkspaceMapImpl implements PluginWorkspaceMap {
         if (mapFile.isFile()) {
             try (InputStream is = new FileInputStream(mapFile)) {
                 p.load(is);
+            } catch (IllegalArgumentException x) {
+                throw new IOException("Malformed " + mapFile + ": " + x, x);
             }
         }
         return p;


### PR DESCRIPTION
Observed a plugin build failure

```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.37:test-hpl (default-test-hpl) on project the-plugin-name: Execution default-test-hpl of goal org.jenkins-ci.tools:maven-hpi-plugin:3.37:test-hpl failed: Malformed \uxxxx encoding.
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:375)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:351)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:215)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:171)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:163)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at …
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-test-hpl of goal org.jenkins-ci.tools:maven-hpi-plugin:3.37:test-hpl failed: Malformed \uxxxx encoding.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:148)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:370)
	... 12 common frames omitted
Caused by: java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
	at java.base/java.util.Properties.loadConvert(Properties.java:678)
	at java.base/java.util.Properties.load0(Properties.java:454)
	at java.base/java.util.Properties.load(Properties.java:407)
	at org.jenkinsci.maven.plugins.hpi.PluginWorkspaceMapImpl.loadMap(PluginWorkspaceMapImpl.java:38)
	at org.jenkinsci.maven.plugins.hpi.PluginWorkspaceMapImpl.write(PluginWorkspaceMapImpl.java:61)
	at org.jenkinsci.maven.plugins.hpi.TestHplMojo.computeHplFile(TestHplMojo.java:37)
	at org.jenkinsci.maven.plugins.hpi.HplMojo.execute(HplMojo.java:69)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	... 13 common frames omitted
```

Seems my `~/.jenkins-hpl-map` had been corrupted recently and contained long stretches of `\u0000`. This ought to have been handled more gracefully: https://github.com/jenkinsci/maven-hpi-plugin/blob/52790b95cabe116ad9ca11288974d43b88371e6a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestHplMojo.java#L37-L39

(Root cause was probably lack of atomic write. Using `mvnd` with multithreading, though `TestHplMojo` is not marked `threadSafe` either, so I suspect the problem was caused by a recent interrupted build.)
