### PR TITLE
Support directories with spaces

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestRuntimeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestRuntimeMojo.java
@@ -131,7 +131,7 @@ public class TestRuntimeMojo extends AbstractJenkinsMojo {
 
         Path insaneHook = getInsaneHook(wrap(jth), patchModuleDir.toPath());
 
-        String argLine = String.format("--patch-module=java.base=%s --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED", insaneHook);
+        String argLine = String.format("--patch-module='java.base=%s' --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED", insaneHook);
         getLog().info("Setting jenkins.insaneHook to " + argLine);
         project.getProperties().setProperty("jenkins.insaneHook", argLine);
     }


### PR DESCRIPTION
Fixes #441. Tested in both Linux and Windows with a directory with spaces.