### PR TITLE
Remove unnecessary managed dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
         <version>1.15</version>
       </dependency>
       <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>1.3.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${maven.version}</version>


### PR DESCRIPTION
With the upgrade to Jetty 10, there is no longer a require upper bounds conflict with this dependency, so there is also no need to manage it at any particular version.