### PR TITLE
fix filtering of web resources using system properties and escaping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-filtering</artifactId>
+      <version>3.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
       <version>3.2.1</version>
     </dependency>
@@ -212,7 +217,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <!-- generated help mojo has a dependency on plexus utils -->
       <version>3.5.1</version>
     </dependency>
     <dependency>

--- a/src/it/warResources/src/main/webResource-filtering/help-globalConfig.html
+++ b/src/it/warResources/src/main/webResource-filtering/help-globalConfig.html
@@ -7,12 +7,12 @@
   </p>
   <p>
     You can also filter using interpolation like: 
-    \${prop1\} ${prop1}
+    \${prop1} ${prop1}
     or 
     \@prop2\@ @prop2@
     and these will be replaced at build time
     it is even possible to use system properties
-    \@java.class.version\@ ${java.class.version}
+    \@java.vendor.url\@ ${java.vendor.url}
   </p>
 
 </div>

--- a/src/it/warResources/verify.groovy
+++ b/src/it/warResources/verify.groovy
@@ -17,11 +17,9 @@
  * under the License.
  */
 globalConfigHelp  = new File(basedir, 'target/war-resources-it/help-globalConfig.html').text;
-// code uses plexus not maven so escapes are not supported.
-assert globalConfigHelp.contains("\\\${prop1\\} hello");
-assert globalConfigHelp.contains("\\@prop2\\@ goodbye");
-// code claims to add System properties but this fails
-// assert globalConfigHelp.contains("\\@java.class.version\\@ 55.0");
+assert globalConfigHelp.contains('${prop1} hello');
+assert globalConfigHelp.contains('@prop2@ goodbye');
+assert globalConfigHelp.contains('@java.vendor.url@ https://');
 
 
 return true;


### PR DESCRIPTION
* Filtering `webResources` now consults `System.getProperties()`  (again?)
* Filtering is now escapable so you can write `\${project.version}` and not have it replaced by the project version. (this matches Mavens' default behaviour

Replaces code from plexus-util with maven-filtering.

The code still directly uses some plexus-util so the dependency is not removed but the comment was no longer correct so that was removed.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
