### PR TITLE
Remove `overrideWarAdditions` option

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -109,19 +109,11 @@ public class TestDependencyMojo extends AbstractHpiMojo {
     /**
      * Path to a Jenkins WAR file with bundled plugins to apply during testing.
      * <p>Dependencies already present in the project model or their transitive dependencies will be updated to the versions in the WAR.
-     * Dependencies not already present in the project model will be added to the project model only if {@link #overrideWarAdditions} is set.
      * <p>May be combined with {@code overrideVersions} so long as the results do not conflict.
      * <p>The version of the WAR must be identical to {@code jenkins.version}.
      */
     @Parameter(property = "overrideWar")
     private File overrideWar;
-
-    /**
-     * Indicates that all plugins bundled in {@link #overrideWar} should be added to the project model even if not originally mentioned.
-     * Would normally complement setting the system property {@code jth.jenkins-war.path} to that WAR.
-     */
-    @Parameter(property = "overrideWarAdditions")
-    private boolean overrideWarAdditions;
 
     /**
      * Whether to update all transitive dependencies to the upper bounds. Effectively causes the
@@ -200,7 +192,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             }
 
             // First pass: apply the overrides specified by the user.
-            applyOverrides(overrides, bundledPlugins, false, overrideWarAdditions, shadow, getLog());
+            applyOverrides(overrides, bundledPlugins, false, shadow, getLog());
 
             if (useUpperBounds) {
                 boolean converged = false;
@@ -244,7 +236,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                         Set<Artifact> resolved = resolveDependencies(shadow);
                         shadow.setArtifacts(resolved);
 
-                        applyOverrides(upperBounds, Map.of(), true, overrideWarAdditions, shadow, getLog());
+                        applyOverrides(upperBounds, Map.of(), true, shadow, getLog());
                     }
                 }
             } else if (!upperBoundsExcludes.isEmpty()) {
@@ -581,7 +573,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             Map<String, String> overrides,
             Map<String, String> bundledPlugins,
             boolean upperBounds,
-            boolean overrideWarAdditions,
             MavenProject project,
             Log log)
             throws MojoExecutionException {
@@ -676,30 +667,27 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             }
         }
 
-        if (overrideWarAdditions) {
-            /*
-             * If a bundled plugin was added that is neither in the model nor the transitive dependency
-             * chain, add a test-scoped direct dependency to the model. This is necessary in order for
-             * us to be able to correctly populate target/test-dependencies/ later on.
-             */
-            Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
-            unappliedBundledPlugins.removeAll(appliedBundledPlugins);
-            for (String key : unappliedBundledPlugins) {
-                String[] groupArt = key.split(":");
-                String groupId = groupArt[0];
-                String artifactId = groupArt[1];
-                String version = bundledPlugins.get(key);
-                Dependency dependency = new Dependency();
-                dependency.setGroupId(groupId);
-                dependency.setArtifactId(artifactId);
-                dependency.setVersion(version);
-                dependency.setScope(Artifact.SCOPE_TEST);
-                if (dependency.getGroupId().equals(project.getGroupId()) && dependency.getArtifactId().equals(project.getArtifactId())) {
-                    throw new MojoExecutionException("Cannot add self as test-scoped dependency");
-                }
-                log.info(String.format("Adding test-scoped direct dependency %s:%s", key, version));
-                project.getDependencies().add(dependency);
+        /*
+         * If a bundled plugin was added that is neither in the model nor the transitive dependency
+         * chain, add a dependency management entry to the model. This is necessary in order for us
+         * to be able to correctly populate target/test-dependencies/ later on.
+         */
+        Set<String> unappliedBundledPlugins = new HashSet<>(bundledPlugins.keySet());
+        unappliedBundledPlugins.removeAll(appliedBundledPlugins);
+        for (String key : unappliedBundledPlugins) {
+            String[] groupArt = key.split(":");
+            String groupId = groupArt[0];
+            String artifactId = groupArt[1];
+            String version = bundledPlugins.get(key);
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(groupId);
+            dependency.setArtifactId(artifactId);
+            dependency.setVersion(version);
+            if (dependency.getGroupId().equals(project.getGroupId()) && dependency.getArtifactId().equals(project.getArtifactId())) {
+                throw new MojoExecutionException("Cannot add self as test-scoped dependency");
             }
+            log.info(String.format("Adding dependency management entry %s:%s", key, version));
+            project.getDependencyManagement().getDependencies().add(dependency);
         }
 
         log.debug("adjusted dependencies: " + project.getDependencies());


### PR DESCRIPTION
`jenkinsci/bom` is using `-DoverrideWarAdditions`, while CloudBees is not. This PR removes the most controversial part of `-DoverrideWarAdditions` (adding the entries to test scope) while retaining the part of it that is needed for `jenkinsci/bom` (adding the bundled plugins that are not part of the original dependency tree to the dependency management section), now the default behavior. Hopefully this will not cause any problems for CloudBees so that we can unify the two implementations.

I plan to test this in `jenkinsci/bom` and would request someone also test this on the CloudBees side.