### PR TITLE
Add option to record commit hashes for Launchable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
       <version>1.11</version>
     </dependency>
     <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.314</version>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-groovy</artifactId>
       <version>1777.v7c6fe6d54a_0c</version>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -5,6 +5,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.internal.LifecycleDependencyResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Scm;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -56,6 +58,7 @@ import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
@@ -71,6 +74,10 @@ import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.kohsuke.github.GHRef;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTagObject;
+import org.kohsuke.github.GitHub;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
 /**
@@ -89,6 +96,10 @@ public class TestDependencyMojo extends AbstractHpiMojo {
     private static final Pattern CORE_REGEX = Pattern.compile("WEB-INF/lib/jenkins-core-([0-9.]+(?:-[0-9a-f.]+)*(?:-(?i)([a-z]+)(-)?([0-9a-f.]+)?)?(?:-(?i)([a-z]+)(-)?([0-9a-f_.]+)?)?(?:-SNAPSHOT)?)[.]jar");
     private static final Pattern PLUGIN_REGEX = Pattern.compile("WEB-INF/plugins/([^/.]+)[.][hj]pi");
     private static final Pattern OVERRIDE_REGEX = Pattern.compile("([^:]+:[^:]+):([^:]+)");
+
+    private static final String PREFIX = "scm:git:https://github.com/";
+    private static final String SUFFIX = ".git";
+    private static final Pattern SHA1_HASH = Pattern.compile("^[a-f0-9]{40}$");
 
     @Component private BuildPluginManager pluginManager;
 
@@ -130,6 +141,12 @@ public class TestDependencyMojo extends AbstractHpiMojo {
      */
     @Parameter(property = "upperBoundsExcludes")
     private List<String> upperBoundsExcludes;
+
+    /**
+     * Path to a file to print commit hashes for Jenkins project dependencies.
+     */
+    @Parameter(property = "commitHashes")
+    private File commitHashes;
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -314,6 +331,8 @@ public class TestDependencyMojo extends AbstractHpiMojo {
 
         copyTestDependencies(effectiveArtifacts);
 
+        printCommitHashes(effectiveArtifacts, commitHashes);
+
         if (!additions.isEmpty() || !deletions.isEmpty() || !updates.isEmpty()) {
             List<String> additionalClasspathElements = new LinkedList<>();
             NavigableMap<String, String> includes = new TreeMap<>();
@@ -462,6 +481,89 @@ public class TestDependencyMojo extends AbstractHpiMojo {
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to copy dependency plugins", e);
+        }
+    }
+
+    private void printCommitHashes(Set<MavenArtifact> mavenArtifacts, File commitHashes) throws MojoExecutionException {
+        if (commitHashes == null) {
+            return;
+        }
+        NavigableMap<String, String> nameToTag = new TreeMap<>();
+        GitHub github;
+        try {
+            github = GitHub.connect();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        for (MavenArtifact mavenArtifact : mavenArtifacts) {
+            Scm scm;
+            try {
+                scm = mavenArtifact.resolvePom().getScm();
+            } catch (ProjectBuildingException e) {
+                throw new MojoExecutionException("Failed to resolve POM for artifact " + mavenArtifact, e);
+            }
+            String org = null;
+            String repo = null;
+            String tag = null;
+            if (scm != null) {
+                String gitHubRepo = scm.getConnection();
+                if (gitHubRepo != null && gitHubRepo.startsWith(PREFIX)) {
+                    gitHubRepo = gitHubRepo.substring(gitHubRepo.indexOf(PREFIX) + PREFIX.length());
+                    if (gitHubRepo.endsWith(SUFFIX)) {
+                        gitHubRepo = gitHubRepo.substring(0, gitHubRepo.indexOf(SUFFIX));
+                    }
+                    String[] parts = gitHubRepo.split("/", 2);
+                    if (parts.length == 2) {
+                        org = parts[0];
+                        repo = parts[1];
+                    }
+                }
+                if (scm.getTag() != null && !scm.getTag().equals("HEAD")) {
+                    tag = scm.getTag();
+                }
+            }
+            // TODO add support for incremental PR builds from a fork
+            if ("jenkinsci".equals(org) && repo != null && tag != null) {
+                String name = org + "/" + repo;
+                nameToTag.put(name, tag);
+            }
+        }
+        NavigableMap<String, String> nameToHash = new TreeMap<>();
+        for (Map.Entry<String, String> entry : nameToTag.entrySet()) {
+            String name = entry.getKey();
+            String tag = entry.getValue();
+            String hash;
+            if (SHA1_HASH.matcher(tag).matches()) {
+                hash = tag;
+            } else {
+                hash = tagToHash(name, tag, github);
+            }
+            if (!SHA1_HASH.matcher(hash).matches()) {
+                throw new IllegalStateException("Illegal hash for " + name + ": " + hash);
+            }
+            nameToHash.put(name, hash);
+        }
+        List<String> output = new ArrayList<>();
+        for (Map.Entry<String, String> entry : nameToHash.entrySet()) {
+            getLog().info(String.format("Component %s has hash %s", entry.getKey(), entry.getValue()));
+            output.add("--commit " + entry.getKey() + "=" + entry.getValue());
+        }
+        try (BufferedWriter w = Files.newBufferedWriter(commitHashes.toPath(), StandardCharsets.UTF_8)) {
+            w.write(String.join(" ", output));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String tagToHash(String name, String tag, GitHub github) {
+        try {
+            GHRepository repo = github.getRepository(name);
+            GHRef ref = repo.getRef("tags/" + tag);
+            String sha = ref.getObject().getSha();
+            GHTagObject tagObject = repo.getTagObject(sha);
+            return tagObject.getObject().getSha();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 


### PR DESCRIPTION
Launchable wants commit hashes for every component of a build, so fish this information out of the POMs of the dynamically resolved test dependency tree and massage the information in a format that Launchable can interpret.