### PR TITLE
Add integration test for additional plugin manifest entries

### DIFF
--- a/src/it/metadata-it/invoker.properties
+++ b/src/it/metadata-it/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp clean package -DskipTests

--- a/src/it/metadata-it/plugin1/pom.xml
+++ b/src/it/metadata-it/plugin1/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its.git-metadata</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>plugin1</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>My First Plugin</name>
+  <packaging>hpi</packaging>
+  <url>https://plugins.jenkins.io/plugin1/</url>
+
+</project>

--- a/src/it/metadata-it/plugin1/src/main/resources/index.jelly
+++ b/src/it/metadata-it/plugin1/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div>plugin1</div>

--- a/src/it/metadata-it/plugin2/pom.xml
+++ b/src/it/metadata-it/plugin2/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its.git-metadata</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>multimodule-it-plugin2</artifactId> <!-- intentionally not the same as the containing directory -->
+  <packaging>hpi</packaging>
+
+  <url>https://plugins.jenkins.io/multimodule-it-plugin2/</url>
+
+    <developers>
+        <developer>
+            <id>bob</id>
+            <email>bob@example.com</email>
+            <name>Robert McBobface</name>
+        </developer>
+        <developer>
+            <id>jane</id>
+            <email>jane@example.com</email>
+        </developer>
+    </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>plugin1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/metadata-it/plugin2/src/main/resources/index.jelly
+++ b/src/it/metadata-it/plugin2/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div>multimodule-it-plugin2</div>

--- a/src/it/metadata-it/pom.xml
+++ b/src/it/metadata-it/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.54</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.jenkins-ci.tools.hpi.its.git-metadata</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <jenkins.version>2.361.4</jenkins.version>
+        <hpi-plugin.version>@project.version@</hpi-plugin.version>
+        <gitHubRepo>jenkinsci/maven-hpi-plugin</gitHubRepo>
+    </properties>
+
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/${gitHubRepo}</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <modules>
+        <module>plugin1</module>
+        <module>plugin2</module>
+    </modules>
+
+</project>

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -35,7 +35,7 @@ try (JarFile j1 = new JarFile(p1)) {
     assert attributes.getValue('Url').equals('https://plugins.jenkins.io/plugin1/')
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
     assert attributes.getValue('Plugin-GitHash').length() == 40
-    assert attributes.getValue('Plugin-Module').equals('plugin1') // invoker copies the file so this is where it is actually built.
+    assert attributes.getValue('Plugin-Module').equals('plugin1')
 }
 
 

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -1,0 +1,75 @@
+import java.io.File
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+import java.util.jar.Manifest
+
+assert new File(basedir, 'plugin1/target/plugin1.hpi').exists()
+File p1 = new File(basedir, 'plugin1/target/plugin1.hpi')
+
+assert p1.exists()
+try (JarFile j1 = new JarFile(p1)) {
+    Manifest mf = j1.getManifest()
+    Attributes attributes = mf.getMainAttributes()
+    // there may be other attribute like 'Created-By' that we do not care about we are not checking everything
+    assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
+
+    assert attributes.getValue('Hudson-Version').equals('2.361.4')
+    assert attributes.getValue('Jenkins-Version').equals('2.361.4')
+
+    assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
+    assert attributes.getValue('Artifact-Id').equals('plugin1')
+
+    assert attributes.getValue('Short-Name').equals('plugin1') // artifactId
+    assert attributes.getValue('Implementation-Version').equals('1.0-SNAPSHOT') // version
+
+    // using project.name
+    assert attributes.getValue('Implementation-Title').equals('My First Plugin')
+    assert attributes.getValue('Specification-Title').equals('My First Plugin')
+    assert attributes.getValue('Long-Name').equals('My First Plugin')
+    
+    assert attributes.getValue('Plugin-Developers').isEmpty()
+    assert attributes.getValue('Plugin-License-Name').equals('MIT License')
+    assert attributes.getValue('Plugin-License-Url').equals('https://opensource.org/licenses/MIT')
+    assert attributes.getValue('Plugin-ScmUrl').equals('https://github.com/jenkinsci/maven-hpi-plugin')
+    assert attributes.getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
+    assert attributes.getValue('Url').equals('https://plugins.jenkins.io/plugin1/')
+    assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
+    assert attributes.getValue('Plugin-GitHash').length() == 40
+    assert attributes.getValue('Plugin-Module').equals('plugin1') // invoker copies the file so this is where it is actualy built.
+}
+
+
+assert new File(basedir, 'plugin2/target/multimodule-it-plugin2.hpi').exists();
+File p2 = new File(basedir, 'plugin2/target/multimodule-it-plugin2.hpi')
+
+try (JarFile j2 = new JarFile(p2)) {
+    Manifest mf = j2.getManifest()
+    Attributes attributes = mf.getMainAttributes()
+    assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
+
+    assert attributes.getValue('Hudson-Version').equals('2.361.4')
+    assert attributes.getValue('Jenkins-Version').equals('2.361.4')
+
+    assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
+    assert attributes.getValue('Artifact-Id').equals('multimodule-it-plugin2')
+    assert attributes.getValue('Short-Name').equals('multimodule-it-plugin2') // artifactId
+    assert attributes.getValue('Implementation-Version').equals('1.0-SNAPSHOT') // version
+
+    // project.name not set so should fallback to project.artifactId
+    assert attributes.getValue('Implementation-Title').equals('multimodule-it-plugin2')
+    assert attributes.getValue('Specification-Title').equals('multimodule-it-plugin2')
+    assert attributes.getValue('Long-Name').equals('multimodule-it-plugin2')
+    
+    assert attributes.getValue('Plugin-Developers').equals('Robert McBobface:bob:bob@example.com,:jane:jane@example.com')
+    assert attributes.getValue('Plugin-License-Name').equals('MIT License')
+    assert attributes.getValue('Plugin-License-Url').equals('https://opensource.org/licenses/MIT')
+    assert attributes.getValue('Plugin-ScmUrl').equals('https://github.com/jenkinsci/maven-hpi-plugin')
+    assert attributes.getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
+    assert attributes.getValue('Url').equals('https://plugins.jenkins.io/multimodule-it-plugin2/')
+    assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
+    assert attributes.getValue('Plugin-GitHash').length() == 40
+    assert attributes.getValue('Plugin-Module').equals('plugin2') // invoker copies the file so this is where it is actualy built.
+
+}
+
+return true;

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -68,7 +68,7 @@ try (JarFile j2 = new JarFile(p2)) {
     assert attributes.getValue('Url').equals('https://plugins.jenkins.io/multimodule-it-plugin2/')
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
     assert attributes.getValue('Plugin-GitHash').length() == 40
-    assert attributes.getValue('Plugin-Module').equals('plugin2') // invoker copies the file so this is where it is actualy built.
+    assert attributes.getValue('Plugin-Module').equals('plugin2')
 
 }
 

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -35,7 +35,7 @@ try (JarFile j1 = new JarFile(p1)) {
     assert attributes.getValue('Url').equals('https://plugins.jenkins.io/plugin1/')
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
     assert attributes.getValue('Plugin-GitHash').length() == 40
-    assert attributes.getValue('Plugin-Module').equals('plugin1') // invoker copies the file so this is where it is actualy built.
+    assert attributes.getValue('Plugin-Module').equals('plugin1') // invoker copies the file so this is where it is actually built.
 }
 
 


### PR DESCRIPTION
I erroneously forgot to push the latest changes to #436 at the time which mean the IT for it was still sitting on my local machine only.

Whilst [an ITs](https://github.com/jenkinsci/maven-hpi-plugin/pull/436/files#diff-0f2f097e3b673ee6c7452716ac8a8268a8a65d5c8cdf5631dc9098f9ae2518d2) was adapted there was still no IT to cover a multi-module reactor build - so this IT ensures we have coverage for that.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
