### PR TITLE
Forward compatibility with SHA-256 hashing

### DIFF
--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -7,6 +7,7 @@ assert new File(basedir, 'plugin1/target/plugin1.hpi').exists()
 File p1 = new File(basedir, 'plugin1/target/plugin1.hpi')
 
 assert p1.exists()
+def pattern = /^[a-f0-9]{40}$|^[a-f0-9]{64}$/
 try (JarFile j1 = new JarFile(p1)) {
     Manifest mf = j1.getManifest()
     Attributes attributes = mf.getMainAttributes()
@@ -34,7 +35,8 @@ try (JarFile j1 = new JarFile(p1)) {
     assert attributes.getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
     assert attributes.getValue('Url').equals('https://plugins.jenkins.io/plugin1/')
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
-    assert attributes.getValue('Plugin-GitHash').length() == 40
+    def matcher = attributes.getValue('Plugin-GitHash') =~ pattern
+    assert matcher.matches()
     assert attributes.getValue('Plugin-Module').equals('plugin1')
 }
 
@@ -67,7 +69,8 @@ try (JarFile j2 = new JarFile(p2)) {
     assert attributes.getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
     assert attributes.getValue('Url').equals('https://plugins.jenkins.io/multimodule-it-plugin2/')
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
-    assert attributes.getValue('Plugin-GitHash').length() == 40
+    def matcher = attributes.getValue('Plugin-GitHash') =~ pattern
+    assert matcher.matches()
     assert attributes.getValue('Plugin-Module').equals('plugin2')
 
 }

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -36,6 +36,7 @@ assert content.contains(" holder.format(\"it.msg\");");
 
 assert new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').exists()
 
+def pattern = /^[a-f0-9]{40}$|^[a-f0-9]{64}$/
 Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').toPath()).withCloseable { is ->
   Manifest manifest = new Manifest(is)
   assert !manifest.getMainAttributes().getValue('Build-Jdk-Spec').isEmpty()
@@ -55,7 +56,8 @@ Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').
   assert manifest.getMainAttributes().getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/verify-it-plugin.git')
   assert manifest.getMainAttributes().getValue('Plugin-ScmTag').equals('HEAD')
   assert manifest.getMainAttributes().getValue('Plugin-ScmUrl').equals('https://github.com/jenkinsci/verify-it-plugin')
-  assert manifest.getMainAttributes().getValue('Plugin-GitHash').length() == 40
+  def matcher = manifest.getMainAttributes().getValue('Plugin-GitHash') =~ pattern
+  assert matcher.matches()
   assert manifest.getMainAttributes().getValue('Plugin-Module') == null
   assert manifest.getMainAttributes().getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
   assert manifest.getMainAttributes().getValue('Short-Name').equals('verify-it')


### PR DESCRIPTION
As documented in the [hash function transition](https://git-scm.com/docs/hash-function-transition/) page, Git is transitioning from SHA-1 (the current default) to SHA-256, which can be enabled by running e.g. `git init --object-format=sha256`. This PR prepares for this transition by changing the SHA hash pattern matcher to support either SHA-1 or SHA-256 hashes (it currently supports only SHA-1). To test this I went to this [regex tester](https://www.regexplanet.com/advanced/java/index.html) and inserted both SHA-1 and SHA-256 hashes into the tester and verified that this new pattern matches both correctly.

(Like https://github.com/jenkinsci/jenkins-test-harness/pull/571.)