### PR TITLE
Begin mini-migration from `Plugin-GitHash` to `Implementation-Build`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -220,8 +220,11 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
         addAttributeIfNotNull(mainSection, "Plugin-ScmConnection", project.getScm().getConnection());
         addAttributeIfNotNull(mainSection, "Plugin-ScmTag", project.getScm().getTag());
         addAttributeIfNotNull(mainSection, "Plugin-ScmUrl", project.getScm().getUrl());
-        addAttributeIfNotNull(mainSection, "Plugin-GitHash", getGitHeadSha1());
+        String gitHash = getGitHeadSha1();
+        // Deprecated: Use "Implementation-Build" for consistency with core and core components
+        addAttributeIfNotNull(mainSection, "Plugin-GitHash", gitHash);
         addAttributeIfNotNull(mainSection, "Plugin-Module", getModule());
+        addAttributeIfNotNull(mainSection, "Implementation-Build", gitHash);
     }
 
     /**


### PR DESCRIPTION
For consistency with https://github.com/jenkinsci/pom/pull/419, put the Git hash in `Implementation-Build` rather than `Plugin-GitHash`. For now I am keeping it in `Plugin-GitHash` since it was (very recently) added there for PCT, but I will update PCT to start consuming `Implementation-Build` instead and plan to rip out `Plugin-GitHash` shortly (in a month or so) once it's no longer used by anything (not much is using it today, just the AWS Java SDK plugin I think).