### PR TITLE
Rename `hp` package to `hpi`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -55,7 +55,7 @@ import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
-import org.jenkinsci.maven.plugins.hp.util.Utils;
+import org.jenkinsci.maven.plugins.hpi.util.Utils;
 
 public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateHpiMojo.java
@@ -10,7 +10,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.jenkinsci.maven.plugins.hp.util.Utils;
+import org.jenkinsci.maven.plugins.hpi.util.Utils;
 
 /**
  * Validates dependencies depend on older or equal core than the current plugin.

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/util/Utils.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/util/Utils.java
@@ -1,4 +1,4 @@
-package org.jenkinsci.maven.plugins.hp.util;
+package org.jenkinsci.maven.plugins.hpi.util;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/test/java/org/jenkinsci/maven/plugins/hpi/util/UtilsTest.java
+++ b/src/test/java/org/jenkinsci/maven/plugins/hpi/util/UtilsTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.util.Collections;
 import java.util.Set;
-import org.jenkinsci.maven.plugins.hp.util.Utils;
 import org.junit.Test;
 
 public class UtilsTest {


### PR DESCRIPTION
Typographical error from #449.