### PR TITLE
Migrate from deprecated Plexus Components to non-deprecated JSR 330

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <!-- if we update this all consumers need to be running at least this version -->
     <maven.version>3.8.1</maven.version>
     <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
-    <plexus-containers.version>2.1.1</plexus-containers.version>
     <aether.version>1.1.0</aether.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -108,6 +107,11 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
         <version>4.7.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -160,6 +164,11 @@
       <version>1.2</version>
     </dependency>
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
       <groupId>net.java.sezpoz</groupId>
       <artifactId>sezpoz</artifactId>
       <version>1.13</version>
@@ -188,11 +197,6 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
       <version>3.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <version>${plexus-containers.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -404,13 +408,14 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <version>${plexus-containers.version}</version>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>0.3.5</version>
         <executions>
           <execution>
+            <id>generate-index</id>
             <goals>
-              <goal>generate-metadata</goal>
+              <goal>main-index</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/PluginWorkspaceMapImpl.java
@@ -9,7 +9,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
 import java.util.Properties;
-import org.codehaus.plexus.component.annotations.Component;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 /**
  * Default and currently the only implementation of {@link PluginWorkspaceMap}
@@ -17,7 +18,8 @@ import org.codehaus.plexus.component.annotations.Component;
  * @author Jesse Glick
  * @author Kohsuke Kawaguchi
  */
-@Component(role = PluginWorkspaceMap.class)
+@Named
+@Singleton
 public class PluginWorkspaceMapImpl implements PluginWorkspaceMap {
     private final File mapFile;
 


### PR DESCRIPTION
References:

- https://cwiki.apache.org/confluence/display/MAVEN/Maven+Ecosystem+Cleanup
- https://maven.apache.org/maven-jsr330.html
- https://github.com/eclipse/sisu.plexus/wiki/Plexus-to-JSR330

### Testing done

Ran `mvn hpi:run` with these changes. Put a breakpoint in the constructor to verify it was being correctly created by Guice using JSR 330 annotations. Put a breakpoint where it was used to verify it could still be used as before after construction.