### PR TITLE
Use a constant where possible

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -82,6 +82,7 @@ import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -304,7 +305,7 @@ public class RunMojo extends JettyRunWarMojo {
         // auto-enable stapler trace, unless otherwise configured already.
         setSystemPropertyIfEmpty("stapler.trace", "true");
         // allow Jetty to accept a bigger form so that it can handle update center JSON post
-        setSystemPropertyIfEmpty("org.eclipse.jetty.Request.maxFormContentSize", "-1");
+        setSystemPropertyIfEmpty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
         // general-purpose system property so that we can tell from Jenkins if we are running in the hpi:run mode.
         setSystemPropertyIfEmpty("hudson.hpi.run", "true");
         // expose the current top-directory of the plugin


### PR DESCRIPTION
Relates to https://github.com/jenkinsci/jenkins-test-harness/pull/605. Using a constant improves the maintainability of the code by making it less likely that this code will go stale if the value changes in the future, for example due to a package rename (as happened in the past with `org.mortbay.jetty`).