### PR TITLE
Remove use of Maven Wagon

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,51 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+permissions:
+  contents: read
+  pages: write      # to deploy to Pages
+  id-token: write   # to verify the deployment originates from an appropriate source
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build site
+        run: mvn -B -V -e -ntp -Pquick-build clean verify site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./target/site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/pom.xml
+++ b/pom.xml
@@ -34,18 +34,6 @@
     <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
-  <distributionManagement>
-    <site>
-      <!-- if this deployment fails, it's probably you are missing the entry to set the username in ~/.m2/settings.xml
-               <server>
-                 <id>github.com</id>
-                 <username>git</username>
-               </server>
-      -->
-      <id>github.com</id>
-      <url>gitsite:git@github.com/${gitHubRepo}.git</url>
-    </site>
-  </distributionManagement>
 
   <properties>
     <revision>3.47</revision>
@@ -319,21 +307,6 @@
   </pluginRepositories>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>com.github.stephenc.wagon</groupId>
-              <artifactId>wagon-gitsite</artifactId>
-              <version>0.5</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -426,13 +399,6 @@
         </executions>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-ssh</artifactId>
-        <version>3.5.3</version>
-      </extension>
-    </extensions>
   </build>
 
   <reporting>


### PR DESCRIPTION
Per [this page](https://cwiki.apache.org/confluence/display/MAVEN/Maven+Ecosystem+Cleanup) Maven Wagon is deprecated. This PR eliminates use of Maven Wagon at release time, replacing it with a GitHub Action that uploads the generated site to GitHub Pages on every clean build of the main branch.

### Testing done

I am using this workflow successfully in Job DSL plugin. If there are any issues with this PR I will fix them after merging this PR.

Fixes #492