### PR TITLE
Restore mojo docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,11 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <version>${maven-plugin-tools.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
+        <version>${maven-plugin-tools.version}</version>
+      </plugin>
     </plugins>
   </reporting>
 


### PR DESCRIPTION
Fixup to #499. Restores the mojo docs which inadvertently disappeared in that PR.

### Testing done

Ran `mvn -B -V -e -ntp -Pquick-build clean verify site` and verified the mojo docs were restored in the generated site.