### PR TITLE
remove Plugin-Module manifest entry

### DIFF
--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -37,7 +37,6 @@ try (JarFile j1 = new JarFile(p1)) {
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
     def matcher = attributes.getValue('Plugin-GitHash') =~ pattern
     assert matcher.matches()
-    assert attributes.getValue('Plugin-Module').equals('plugin1')
 }
 
 
@@ -71,8 +70,6 @@ try (JarFile j2 = new JarFile(p2)) {
     assert attributes.getValue('Plugin-ScmConnection').equals('scm:git:https://github.com/jenkinsci/maven-hpi-plugin.git')
     def matcher = attributes.getValue('Plugin-GitHash') =~ pattern
     assert matcher.matches()
-    assert attributes.getValue('Plugin-Module').equals('plugin2')
-
 }
 
 return true;

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -58,7 +58,6 @@ Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').
   assert manifest.getMainAttributes().getValue('Plugin-ScmUrl').equals('https://github.com/jenkinsci/verify-it-plugin')
   def matcher = manifest.getMainAttributes().getValue('Plugin-GitHash') =~ pattern
   assert matcher.matches()
-  assert manifest.getMainAttributes().getValue('Plugin-Module') == null
   assert manifest.getMainAttributes().getValue('Plugin-Version').startsWith('1.0-SNAPSHOT')
   assert manifest.getMainAttributes().getValue('Short-Name').equals('verify-it')
   assert manifest.getMainAttributes().getValue('Specification-Title').equals('MyNewPlugin') // was project.description in previous versions, now project.name

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -237,7 +237,6 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
         String gitHash = getGitHeadSha1();
         // Deprecated: Use "Implementation-Build" for consistency with core and core components
         addAttributeIfNotNull(mainSection, "Plugin-GitHash", gitHash);
-        addAttributeIfNotNull(mainSection, "Plugin-Module", getModule());
         addAttributeIfNotNull(mainSection, "Implementation-Build", gitHash);
     }
 


### PR DESCRIPTION
THe manifest entry was not correctly caclulated, being different depending on where you ran maven from and if you also had any local aggrgator project or not.

The original intention and need of this was to use the path from the git repostory for the PCT, but the code changed from using a git path along the way.

As a result the code produced non deterministic results and the PCT which needed this information has been updated to not need this in https://github.com/jenkinsci/plugin-compat-tester/pull/557

because the information is non deterministic and there are no consumers of this, it is simpler to remove the code.

fixes #497 
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
