### PR TITLE
Add Overview menu with link to goals

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -25,6 +25,11 @@
       <item name="Jenkins" href="https://jenkins.io/" />
     </breadcrumbs>
 
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Goals" href="plugin-info.html"/>
+    </menu>
+
     <!-- Menus that every project will inherit -->
     <menu ref="reports" inherit="bottom" />
 


### PR DESCRIPTION
This seems to be standard for Maven plugins. Tested by building the documentation site locally and browsing to the goals page.