### PR TITLE
Migrate from `maven-artifact-transfer` to direct use of Resolver API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,9 @@
     <dollar>$</dollar>
     <openbracket>{</openbracket>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-    <aether.version>1.1.0</aether.version>
     <!-- if we update this all consumers need to be running at least this version -->
     <maven.version>3.8.1</maven.version>
     <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
-    <aether.version>1.1.0</aether.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -67,64 +65,9 @@
         <version>1.15</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-core</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-model</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-plugin-api</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.shared</groupId>
-        <artifactId>maven-shared-utils</artifactId>
-        <version>3.4.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-archiver</artifactId>
-        <version>4.7.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>2.1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-io</artifactId>
-        <version>3.4.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-api</artifactId>
-        <version>${aether.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-impl</artifactId>
-        <version>${aether.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-spi</artifactId>
-        <version>${aether.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-util</artifactId>
-        <version>${aether.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.7</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -173,11 +116,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
       <version>3.2.1</version>
     </dependency>
@@ -220,22 +158,19 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-builder-support</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -247,29 +182,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-repository-metadata</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-resolver-provider</artifactId>
-      <version>${maven.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-settings</artifactId>
-      <version>${maven.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-settings-builder</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -308,26 +226,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <excludes combine.children="append">
-                    <exclude>commons-lang:commons-lang</exclude>
-                    <exclude>org.apache.commons:commons-collections4</exclude>
-                    <exclude>org.apache.commons:commons-lang3</exclude>
-                    <exclude>org.slf4j:slf4j-api</exclude>
-                  </excludes>
-                </requireUpperBoundDeps>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HplMojo.java
@@ -113,7 +113,7 @@ public class HplMojo extends AbstractJenkinsManifestMojo {
      * puts into WEB-INF/lib should be the same so that the plugins see consistent
      * environment.
      */
-    private void buildLibraries(List<String> paths) throws IOException {
+    private void buildLibraries(List<String> paths) throws IOException, MojoExecutionException {
         Set<MavenArtifact> artifacts = getProjectArtfacts();
 
         // List up IDs of Jenkins plugin dependencies

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestRuntimeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestRuntimeMojo.java
@@ -18,10 +18,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 
 /**
  * Configure Surefire for the desired version of Java.
@@ -73,22 +69,9 @@ public class TestRuntimeMojo extends AbstractJenkinsMojo {
 
     @NonNull
     private Artifact resolveJenkinsWar() throws MojoExecutionException {
-        DefaultArtifactCoordinate artifactCoordinate = new DefaultArtifactCoordinate();
-        artifactCoordinate.setGroupId("org.jenkins-ci.main");
-        artifactCoordinate.setArtifactId("jenkins-war");
-        artifactCoordinate.setVersion(findJenkinsVersion());
-        artifactCoordinate.setExtension("war");
-
-        try {
-            ProjectBuildingRequest buildingRequest =
-                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-            buildingRequest.setRemoteRepositories(project.getRemoteArtifactRepositories());
-            return artifactResolver
-                    .resolveArtifact(buildingRequest, artifactCoordinate)
-                    .getArtifact();
-        } catch (ArtifactResolverException e) {
-            throw new MojoExecutionException("Couldn't download artifact: ", e);
-        }
+        Artifact artifact =
+                artifactFactory.createArtifact("org.jenkins-ci.main", "jenkins-war", findJenkinsVersion(), null, "war");
+        return MavenArtifact.resolveArtifact(artifact, project, session, repositorySystem);
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/WarMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/WarMojo.java
@@ -12,11 +12,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Zip;
 import org.apache.tools.ant.types.ZipFileSet;
@@ -90,10 +87,7 @@ public class WarMojo extends RunMojo {
                 // find corresponding .hpi file
                 Artifact hpi =
                         artifactFactory.createArtifact(a.getGroupId(), a.getArtifactId(), a.getVersion(), null, "hpi");
-                ProjectBuildingRequest buildingRequest =
-                        new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-                buildingRequest.setRemoteRepositories(project.getRemoteArtifactRepositories());
-                hpi = artifactResolver.resolveArtifact(buildingRequest, hpi).getArtifact();
+                hpi = MavenArtifact.resolveArtifact(hpi, project, session, repositorySystem);
 
                 if (hpi.getFile().isDirectory()) {
                     throw new UnsupportedOperationException(
@@ -110,7 +104,7 @@ public class WarMojo extends RunMojo {
             getLog().info("Generated " + outputFile);
 
             projectHelper.attachArtifact(getProject(), "war", outputFile);
-        } catch (IOException | ArtifactResolverException e) {
+        } catch (IOException e) {
             throw new MojoExecutionException("Failed to package war", e);
         }
     }


### PR DESCRIPTION
Fixes #469

### Testing done

Ran builds of `text-finder` (including `hpi:run`) and Jenkins core with these changes.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
