### PR TITLE
Support Ubuntu version of OpenJDK in tests

### DIFF
--- a/src/it/warResources/src/main/webResource-filtering/help-globalConfig.html
+++ b/src/it/warResources/src/main/webResource-filtering/help-globalConfig.html
@@ -12,7 +12,7 @@
     \@prop2\@ @prop2@
     and these will be replaced at build time
     it is even possible to use system properties
-    \@java.vendor.url\@ ${java.vendor.url}
+    \@java.runtime.name\@ ${java.runtime.name}
   </p>
 
 </div>

--- a/src/it/warResources/verify.groovy
+++ b/src/it/warResources/verify.groovy
@@ -19,7 +19,7 @@
 globalConfigHelp  = new File(basedir, 'target/war-resources-it/help-globalConfig.html').text;
 assert globalConfigHelp.contains('${prop1} hello');
 assert globalConfigHelp.contains('@prop2@ goodbye');
-assert globalConfigHelp.contains('@java.vendor.url@ https://');
+assert globalConfigHelp.contains('@java.runtime.name@ OpenJDK');
 
 
 return true;


### PR DESCRIPTION
This test fails for me locally on Ubuntu with the Ubuntu OpenJDK 17 package because the test relies on `java.vendor.url` being set to a URL that starts with `https://` but for some reason the Ubuntu package doesn't define a URL so this just returns "Unknown" and the test fails. By testing a different system property instead the test passes on both Eclipse Temurin and Ubuntu builds of OpenJDK.