### PR TITLE
Restore build stability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def runTests(Map params = [:]) {
             }
             // Needed for correct computation of JenkinsHome in RunMojo#execute.
             withEnv(['JENKINS_HOME=', 'HUDSON_HOME=']) {
-              infra.runMaven(args, params['jdk'])
+              infra.runMaven(args, params['jdk'], null, null, false)
             }
           }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,7 @@
           <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
           <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
           <settingsFile>src/it/settings.xml</settingsFile>
+          <mergeUserSettings>true</mergeUserSettings>
           <pomIncludes>
             <pomInclude>*</pomInclude>
           </pomIncludes>


### PR DESCRIPTION
This change fixes https://github.com/jenkinsci/maven-hpi-plugin/issues/534 by allowing Integration Tests to execute in the context of ci.jenkins.io with its `settings.xml` mirroring setup.

This change is tested with and without a custom `settings.xml` to ensure both contributors and ci.jenkins.io environments are considered.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
