### PR TITLE
Remove Mock Repository Manager Maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ mvn -f ../some-plugin -Dhpi-plugin.version=2.XXX-SNAPSHOT -DskipTests -DjenkinsH
 You can also rerun one test:
 
 ```bash
-mvn -Prun-its mrm:start invoker:run mrm:stop -Dinvoker.test=parent-4x
+mvn -Prun-its invoker:run -Dinvoker.test=parent-4x
 ```
 
 To rerun just the verification script:

--- a/pom.xml
+++ b/pom.xml
@@ -250,9 +250,6 @@
             <pomInclude>*</pomInclude>
           </pomIncludes>
           <postBuildHookScript>verify</postBuildHookScript>
-          <filterProperties>
-            <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
-          </filterProperties>
           <environmentVariables>
             <!-- block anything set by a CI environment -->
             <JENKINS_HOME />
@@ -282,17 +279,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>mrm-maven-plugin</artifactId>
-        <version>1.5.0</version>
-        <configuration>
-          <propertyName>repository.proxy.url</propertyName>
-          <repositories>
-            <proxyRepo />
-          </repositories>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
@@ -338,18 +324,6 @@
                 <goals>
                   <goal>install</goal>
                   <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>mrm-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>start</goal>
-                  <goal>stop</goal>
                 </goals>
               </execution>
             </executions>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -22,14 +22,6 @@ under the License.
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
   xmlns="http://maven.apache.org/SETTINGS/1.1.0">
-  <mirrors>
-    <mirror>
-      <id>mrm-maven-plugin</id>
-      <name>Mock Repository Manager</name>
-      <url>@repository.proxy.url@</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
   <profiles>
     <profile>
       <id>it-repo</id>


### PR DESCRIPTION
I cannot see a reason to continue using `mrm-maven-plugin`. Based on https://www.mojohaus.org/mrm/mrm-maven-plugin/examples/invoker-tests.html it seems the reason for using it was originally

> to allow the integration tests of a Maven Plugin to be run against a test local repository thereby ensuring that the plugin does not get installed into the local repository until after the integration tests have been confirmed as passing

but I just ran `mvn clean verify` and my local `~/.m2` repository did not seem to get polluted, so I don't think this is a concern anymore now that we are configuring `maven-invoker-plugin` with `localRepositoryPath`.

For what it's worth, I asked Maven developer Tamás Cservenák to audit `maven-hpi-plugin` a few months back, and here is what he had to say:

> I'd avoid the use of mrm plugin. You already pull Jetty, simplest (and most straightforward and least error prone) is to just fire up Jetty to serve files from somewhere as "remote repository" as in that case you are 100% in control of what is being served, while with MRM you are not.