### PR TITLE
Only run GitHub actions from jenkinsci org

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == 'jenkinsci'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Only run GitHub actions from jenkinsci org

No need to deploy site on forks

### Testing done

Technique is working for jenkins.io and for several other repositories.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
