### PR TITLE
Generate automatically a marker file for a maven profile depending on java level to use

### DIFF
--- a/src/it/ensure-java-level-marker-11-migration/invoker.properties
+++ b/src/it/ensure-java-level-marker-11-migration/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp validate

--- a/src/it/ensure-java-level-marker-11-migration/pom.xml
+++ b/src/it/ensure-java-level-marker-11-migration/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.77</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>ensure-java-level-marker-11-migration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>MyNewPlugin</name>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+</project>

--- a/src/it/ensure-java-level-marker-11-migration/verify.groovy
+++ b/src/it/ensure-java-level-marker-11-migration/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/java-level').list().length == 1
+assert new File(basedir, 'target/java-level/11').exists()
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Removing old marker file")
+
+return true

--- a/src/it/ensure-java-level-marker-11/invoker.properties
+++ b/src/it/ensure-java-level-marker-11/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=-ntp validate

--- a/src/it/ensure-java-level-marker-11/pom.xml
+++ b/src/it/ensure-java-level-marker-11/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.77</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>ensure-java-level-marker-11</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>MyNewPlugin</name>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <hpi-plugin.version>@project.version@</hpi-plugin.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+</project>

--- a/src/it/ensure-java-level-marker-11/verify.groovy
+++ b/src/it/ensure-java-level-marker-11/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/java-level').list().length == 1
+assert new File(basedir, 'target/java-level/11').exists()
+
+return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/InitializeMojo.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.maven.plugins.hpi;
+
+import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Configure Maven for the desired version of Java.
+ *
+ * @author Basil Crow
+ */
+@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
+public class InitializeMojo extends AbstractJenkinsMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        setCompilerProperties();
+    }
+
+    private void setCompilerProperties() throws MojoExecutionException {
+        if (!project.getProperties().containsKey("maven.compiler.source")
+                && !project.getProperties().containsKey("maven.compiler.release")) {
+            // On an older plugin parent POM that predates the setting of these values as Maven properties.
+            return;
+        }
+
+        JavaSpecificationVersion javaVersion = getMinimumJavaVersion();
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("9"))) {
+            // Should always be set already, but just in case...
+            setProperty("maven.compiler.source", javaVersion.toString());
+            setProperty("maven.compiler.target", javaVersion.toString());
+            setProperty("maven.compiler.testSource", javaVersion.toString());
+            setProperty("maven.compiler.testTarget", javaVersion.toString());
+            // Should never be set already, but just in case...
+            unsetProperty("maven.compiler.release");
+            unsetProperty("maven.compiler.testRelease");
+        } else {
+            /*
+             * When compiling with a Java 9+ compiler, we always rely on "release" in favor of "source" and "target",
+             * even when compiling to Java 8 bytecode.
+             */
+            setProperty("maven.compiler.release", Integer.toString(javaVersion.toReleaseVersion()));
+            setProperty("maven.compiler.testRelease", Integer.toString(javaVersion.toReleaseVersion()));
+
+            /*
+             * While it does not hurt to have these set to the Java specification version, it is also not needed when
+             * "release" is in use.
+             */
+            unsetProperty("maven.compiler.source");
+            unsetProperty("maven.compiler.target");
+            unsetProperty("maven.compiler.testSource");
+            unsetProperty("maven.compiler.testTarget");
+        }
+    }
+
+    private void setProperty(String key, String value) {
+        String currentValue = project.getProperties().getProperty(key);
+        if (currentValue == null || !currentValue.equals(value)) {
+            getLog().info("Setting " + key + " to " + value);
+            project.getProperties().setProperty(key, value);
+        }
+    }
+
+    private void unsetProperty(String key) {
+        String currentValue = project.getProperties().getProperty(key);
+        if (currentValue != null && !currentValue.isEmpty()) {
+            getLog().info("Unsetting " + key);
+            project.getProperties().remove(key);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/extensions/HpiLifecycleMappingProvider.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/extensions/HpiLifecycleMappingProvider.java
@@ -26,6 +26,7 @@ public final class HpiLifecycleMappingProvider extends AbstractLifecycleMappingP
                 "validate",
                 new LifecyclePhase(
                         "org.jenkins-ci.tools:maven-hpi-plugin:validate,org.jenkins-ci.tools:maven-hpi-plugin:validate-hpi"));
+        bindings.put("initialize", new LifecyclePhase("org.jenkins-ci.tools:maven-hpi-plugin:initialize"));
         bindings.put(
                 "process-resources",
                 new LifecyclePhase("org.apache.maven.plugins:maven-resources-plugin:2.6:resources"));


### PR DESCRIPTION
(This idea came up as a discussion during the Jenkins contributor summit, based on the IDE problems experienced during the transition between Java 8 and 11 support)

This effectively reverts #403, reinstating #323, as well as adding a new mechanism for better IDE support.

The logic of setting `maven.compiler.release` dynamically works fine for the Maven CLI. However IDE support (at least IntelliJ) doesn't work well with this and happily ignores what the plugin set dynamically. Indeed, it has its own logic to parse the pom and apply profiles, but doesn't call any maven lifecycle doing so.

Instead, it picks up the default value set through the plugin pom that defaults to the minimum java version supported (currently [11](https://github.com/jenkinsci/plugin-pom/blob/6949f8af159d30e2722fcf773b397bc870e47359/pom.xml#L61)), instead of the version inferred from Java bytecode version obtained from Jenkins core.

Generating markerfiles allows to enable maven profiles that will set the java release to the correct version when loaded in IDE, as long as they are able to read activated profiles.

<!-- Please describe your pull request here. -->

### Testing done
* Applied this patch
* Patched [plugin-pom](https://github.com/jenkinsci/plugin-pom) (see https://github.com/jenkinsci/plugin-pom/pull/893)
```
Subject: [PATCH] Add java level profiles
---
Index: pom.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/pom.xml b/pom.xml
--- a/pom.xml	(revision 6949f8af159d30e2722fcf773b397bc870e47359)
+++ b/pom.xml	(revision 28d462c55325e673d6f0c1710ac703300abae7b1)
@@ -1453,5 +1453,27 @@
         <yarn.lint.skip>true</yarn.lint.skip>
       </properties>
     </profile>
+    <profile>
+      <id>java-level-17</id>
+      <activation>
+        <file>
+          <exists>target/java-level/17</exists>
+        </file>
+      </activation>
+      <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+      </properties>
+    </profile>
+    <profile>
+      <id>java-level-21</id>
+      <activation>
+        <file>
+          <exists>target/java-level/21</exists>
+        </file>
+      </activation>
+      <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+      </properties>
+    </profile>
   </profiles>
 </project>
```
* built a jenkins snapshot with `-Dmaven.compiler.release=17`

Then in a plugin (I used `parallel-test-executor` as an example)
* Reference `maven-hpi-plugin` snapshot
* Reference `plugin-pom` snapshot
* Imported the project in IntelliJ (2024.1 EAP, they seem to have reworked the maven projects import, so it could matter)
* Check module settings -> Language level is set to 11 (expected)
* Update `jenkins.version` property to the snapshot built above
* Call `mvn validate`
* In IntelliJ, use **Maven > Reload project**
* Check module settings -> See the language level changing to 17 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
