### PR TITLE
JAR and JPI creation is nondeterministic

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractJenkinsManifestMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.model.License;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.archiver.jar.Manifest;
 import org.codehaus.plexus.archiver.jar.ManifestException;
 
@@ -65,6 +66,16 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     private String compatibleSinceVersion;
 
     /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
+     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     *
+     * @since TODO
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
+    /**
      * Optional - sandbox status of this plugin.
      */
     @Parameter
@@ -78,6 +89,19 @@ public abstract class AbstractJenkinsManifestMojo extends AbstractHpiMojo {
     @Deprecated
     @Parameter
     protected String minimumJavaVersion;
+
+    /**
+     * @return an instance of {@link MavenArchiver} preconfigured for reproducible builds
+     *
+     * @since TODO
+     */
+    protected MavenArchiver newMavenArchiver(JarArchiver jarArchiver, File outputFile) {
+        MavenArchiver mavenArchiver = new MavenArchiver();
+        mavenArchiver.setArchiver(jarArchiver);
+        mavenArchiver.setOutputFile(outputFile);
+        mavenArchiver.configureReproducibleBuild(outputTimestamp);
+        return mavenArchiver;
+    }
 
     /**
      * Generates a manifest file to be included in the .hpi file

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/HpiMojo.java
@@ -134,9 +134,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
             // create a jar file to be used when other plugins depend on this plugin.
             jarFile = getOutputFile(".jar");
             getLog().info("Generating jar " + jarFile.getAbsolutePath());
-            MavenArchiver archiver = new MavenArchiver();
-            archiver.setArchiver(jarArchiver);
-            archiver.setOutputFile(jarFile);
+            MavenArchiver archiver = newMavenArchiver(jarArchiver, jarFile);
             jarArchiver.addConfiguredManifest(manifest);
             File indexJelly = new File(getClassesDirectory(), "index.jelly");
             if (!indexJelly.isFile()) {
@@ -165,10 +163,7 @@ public class HpiMojo extends AbstractJenkinsManifestMojo {
         File hpiFile = getOutputFile(".hpi");
         getLog().info("Generating hpi " + hpiFile.getAbsolutePath());
 
-        MavenArchiver archiver = new MavenArchiver();
-
-        archiver.setArchiver(hpiArchiver);
-        archiver.setOutputFile(hpiFile);
+        MavenArchiver archiver = newMavenArchiver(hpiArchiver, hpiFile);
 
         hpiArchiver.addConfiguredManifest(manifest);
         hpiArchiver.addDirectory(getWebappDirectory(), getIncludes(), getExcludes());

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/JarMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/JarMojo.java
@@ -106,9 +106,7 @@ public class JarMojo extends AbstractJenkinsManifestMojo {
 
         // create a jar file to be used when other plugins depend on this plugin.
         File jarFile = getOutputFile(".jar");
-        MavenArchiver archiver = new MavenArchiver();
-        archiver.setArchiver(jarArchiver);
-        archiver.setOutputFile(jarFile);
+        MavenArchiver archiver = newMavenArchiver(jarArchiver, jarFile);
         jarArchiver.addConfiguredManifest(manifest);
         jarArchiver.addDirectory(getClassesDirectory());
         archiver.createArchive(session, project, archive);


### PR DESCRIPTION
Fixes #598

### Testing done

Ensured that when defining `project.build.outputTimestamp` in a plugin the JAR and JPI were created with sorted zip entries.