### PR TITLE
Fix test failure

### DIFF
--- a/src/test/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojoTest.java
+++ b/src/test/java/org/jenkinsci/maven/plugins/hpi/TestInsertionMojoTest.java
@@ -3,7 +3,7 @@ package org.jenkinsci.maven.plugins.hpi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
 
 public class TestInsertionMojoTest {
@@ -17,7 +17,7 @@ public class TestInsertionMojoTest {
                 "_123org.jenkins_ci.maven.plugins.hpi",
                 TestInsertionMojo.legalizePackageName("123org.jenkins-ci.maven.plugins.hpi"));
         assertThrows(
-                MojoExecutionException.class,
+                MojoFailureException.class,
                 () -> TestInsertionMojo.legalizePackageName("org.jenkinsci%maven.plugins.hpi"));
     }
 }


### PR DESCRIPTION
Amends #587 to fix this test failure I got locally:

```
java.lang.AssertionError: unexpected exception type thrown; expected:<org.apache.maven.plugin.MojoExecutionException> but was:<org.apache.maven.plugin.MojoFailureException>
        at org.junit.Assert.assertThrows(Assert.java:1020)
        at org.junit.Assert.assertThrows(Assert.java:981)
        at org.jenkinsci.maven.plugins.hpi.TestInsertionMojoTest.legalizePackageName(TestInsertionMojoTest.java:19)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: org.apache.maven.plugin.MojoFailureException: Could not convert org.jenkinsci%maven.plugins.hpi to a legal java package name. Please override "injectedTestPackage" with a valid java package name.
        at org.jenkinsci.maven.plugins.hpi.TestInsertionMojo.legalizePackageName(TestInsertionMojo.java:192)
        at org.jenkinsci.maven.plugins.hpi.TestInsertionMojoTest.lambda$legalizePackageName$0(TestInsertionMojoTest.java:21)
        at org.junit.Assert.assertThrows(Assert.java:1001)
        ... 28 more
```

This updates the test to match the production code, which throws `MojoFailureException`.

### Testing done

Test now passes.