### PR TITLE
Inline `ContextHandler.MAX_FORM_CONTENT_SIZE_KEY`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -89,7 +89,6 @@ import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -317,7 +316,7 @@ public class RunMojo extends JettyRunWarMojo {
         // auto-enable stapler trace, unless otherwise configured already.
         setSystemPropertyIfEmpty("stapler.trace", "true");
         // allow Jetty to accept a bigger form so that it can handle update center JSON post
-        setSystemPropertyIfEmpty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
+        setSystemPropertyIfEmpty("org.eclipse.jetty.server.Request.maxFormContentSize", "-1");
         // general-purpose system property so that we can tell from Jenkins if we are running in the hpi:run mode.
         setSystemPropertyIfEmpty("hudson.hpi.run", "true");
         // expose the current top-directory of the plugin


### PR DESCRIPTION
Jetty 10:

```
jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
145:    public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
```

Jetty 12:

```
jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
42:    public static final String MAX_LENGTH_ATTRIBUTE = "org.eclipse.jetty.server.Request.maxFormContentSize";
```

As you can see, the string is the same, but now lives in `FormFields.MAX_LENGTH_ATTRIBUTE` rather than `ContextHandler.MAX_FORM_CONTENT_SIZE_KEY`.

To prepare ourselves for the transition, simplest just to inline the string so that we aren't depending on any particular calling convention.

### Testing done

`mvn clean install`