### PR TITLE
Stop shadowing field

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -63,7 +63,6 @@ import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderExcept
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
@@ -99,9 +98,6 @@ public class TestDependencyMojo extends AbstractHpiMojo {
 
     @Component
     private ProjectDependenciesResolver dependenciesResolver;
-
-    @Component
-    private RepositorySystem repositorySystem;
 
     /**
      * List of dependency version overrides in the form {@code groupId:artifactId:version} to apply


### PR DESCRIPTION
This field exists two levels up the class hierarchy, so shadowing it here is pointless. It is also actively harmful, as it causes the injector to inject it in the lowest level of the class hierarchy but not in the grandparent class, causing references to it in the grandparent class (of which there currently are none, but will be in a future change I'm working on) to fail with a `NullPointerException`.

### Testing done

CI build