### PR TITLE
chore(pipeline) use Artifact Caching Proxy to speed up CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,13 +18,15 @@ def runTests(Map params = [:]) {
         }
         stage("Build (${stageIdentifier})") {
           ansiColor('xterm') {
-            def args = ['-Dstyle.color=always', '-Prun-its', '-Dmaven.test.failure.ignore', 'clean', 'install', 'site']
-            if (publishing) {
-              args += '-Dset.changelist'
-            }
-            // Needed for correct computation of JenkinsHome in RunMojo#execute.
-            withEnv(['JENKINS_HOME=', 'HUDSON_HOME=']) {
-              infra.runMaven(args, params['jdk'], null, null, false)
+            infra.withArtifactCachingProxy(true) {
+              def args = ['-Dstyle.color=always', '-Prun-its', '-Dmaven.test.failure.ignore', 'clean', 'install', 'site']
+              if (publishing) {
+                args += '-Dset.changelist'
+              }
+              // Needed for correct computation of JenkinsHome in RunMojo#execute.
+              withEnv(['JENKINS_HOME=', 'HUDSON_HOME=']) {
+                infra.runMaven(args, params['jdk'], null, null, false)
+              }
             }
           }
         }


### PR DESCRIPTION
This PR is another try (following https://github.com/jenkinsci/maven-hpi-plugin/pull/537) at enabling Artifact Caching Proxy ("ACP") to speed up build and contribute to the effort of decreasing bandwidth usage on repo.jenkins-ci.org Artifactory.

It tries to use the pipeline library function created since last attempts, providing a boolean feature switch in case of issue with the ACP service.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
