### PR TITLE
Require 2.452.x or newer

### DIFF
--- a/src/it/JENKINS-45740-metadata/pom.xml
+++ b/src/it/JENKINS-45740-metadata/pom.xml
@@ -34,7 +34,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!--Examples of real use-cases-->

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -23,8 +23,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1580.v47b_429a_c853a</version>
+        <artifactId>bom-2.452.x</artifactId>
+        <version>3010.vec758b_8e7da_3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -23,8 +23,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1580.v47b_429a_c853a</version>
+        <artifactId>bom-2.452.x</artifactId>
+        <version>3010.vec758b_8e7da_3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -23,8 +23,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1580.v47b_429a_c853a</version>
+        <artifactId>bom-2.452.x</artifactId>
+        <version>3010.vec758b_8e7da_3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/assemble-dependencies-as-jpi/pom.xml
+++ b/src/it/assemble-dependencies-as-jpi/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/assemble-dependencies/pom.xml
+++ b/src/it/assemble-dependencies/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/check-core-version-failure/pom.xml
+++ b/src/it/check-core-version-failure/pom.xml
@@ -11,7 +11,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -22,9 +22,9 @@
       <version>2.14.1-313.v504cdd45c18b</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-      <version>1214.v1de940103927</version>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>1460.v28178c1ef6e6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/check-core-version-failure/verify.groovy
+++ b/src/it/check-core-version-failure/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains("Dependency org.jenkins-ci.plugins:credentials:jar:1214.v1de940103927 requires Jenkins 2.375 or higher.")
+assert new File(basedir, 'build.log').getText('UTF-8').contains("Dependency org.jenkins-ci.plugins.workflow:workflow-job:jar:1460.v28178c1ef6e6 requires Jenkins 2.479.1 or higher.")
 
 return true;

--- a/src/it/check-core-version-success/pom.xml
+++ b/src/it/check-core-version-success/pom.xml
@@ -11,7 +11,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/compile-fork-it/pom.xml
+++ b/src/it/compile-fork-it/pom.xml
@@ -16,7 +16,7 @@
   <name>MyNewPlugin</name>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/compile-it/pom.xml
+++ b/src/it/compile-it/pom.xml
@@ -16,7 +16,7 @@
   <name>MyNewPlugin</name>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/compile-multimodule-it/pom.xml
+++ b/src/it/compile-multimodule-it/pom.xml
@@ -19,7 +19,7 @@
     <module>plugin2</module>
   </modules>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/ensure-java-level-marker-11-migration/pom.xml
+++ b/src/it/ensure-java-level-marker-11-migration/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/ensure-java-level-marker-11/pom.xml
+++ b/src/it/ensure-java-level-marker-11/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/java-level/pom.xml
+++ b/src/it/java-level/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <java.level>11</java.level>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/it/jenkins-version/pom.xml
+++ b/src/it/jenkins-version/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.360</jenkins.version>
+    <jenkins.version>2.451</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/jenkins-version/verify.groovy
+++ b/src/it/jenkins-version/verify.groovy
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-assert new File(basedir, 'build.log').getText('UTF-8').contains('This version of maven-hpi-plugin requires Jenkins 2.361 or later')
+assert new File(basedir, 'build.log').getText('UTF-8').contains('This version of maven-hpi-plugin requires Jenkins 2.452 or later')
 
 return true

--- a/src/it/metadata-it/pom.xml
+++ b/src/it/metadata-it/pom.xml
@@ -34,7 +34,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <gitHubRepo>jenkinsci/maven-hpi-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -14,8 +14,8 @@ try (JarFile j1 = new JarFile(p1)) {
     // there may be other attribute like 'Created-By' that we do not care about we are not checking everything
     assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
 
-    assert attributes.getValue('Hudson-Version').equals('2.361.4')
-    assert attributes.getValue('Jenkins-Version').equals('2.361.4')
+    assert attributes.getValue('Hudson-Version').equals('2.452.4')
+    assert attributes.getValue('Jenkins-Version').equals('2.452.4')
 
     assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
     assert attributes.getValue('Artifact-Id').equals('plugin1')
@@ -48,8 +48,8 @@ try (JarFile j2 = new JarFile(p2)) {
     Attributes attributes = mf.getMainAttributes()
     assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
 
-    assert attributes.getValue('Hudson-Version').equals('2.361.4')
-    assert attributes.getValue('Jenkins-Version').equals('2.361.4')
+    assert attributes.getValue('Hudson-Version').equals('2.452.4')
+    assert attributes.getValue('Jenkins-Version').equals('2.452.4')
 
     assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
     assert attributes.getValue('Artifact-Id').equals('multimodule-it-plugin2')

--- a/src/it/minimum-java-version/pom.xml
+++ b/src/it/minimum-java-version/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -14,7 +14,7 @@
   <name>MyNewPlugin</name>
   <description>Deprecated spot for plugin description.</description>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/override-test-dependencies-release-failure/pom.xml
+++ b/src/it/override-test-dependencies-release-failure/pom.xml
@@ -11,7 +11,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/override-test-dependencies-smokes/pom.xml
+++ b/src/it/override-test-dependencies-smokes/pom.xml
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <!-- TODO cannot include `invoker.goals=-DoverrideVersions=…,… test` in invoker.properties since then that is misinterpreted as multiple arguments for invoker.goals -->
     <overrideVersions>org.jenkins-ci.plugins.workflow:workflow-step-api:2.11,org.jenkins-ci.plugins.workflow:workflow-api:2.17,org.jenkins-ci.plugins.workflow:workflow-cps:2.32</overrideVersions>

--- a/src/it/override-war-with-snapshot/dependant/pom.xml
+++ b/src/it/override-war-with-snapshot/dependant/pom.xml
@@ -47,6 +47,6 @@
     </dependency>
   </dependencies>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
   </properties>
 </project>

--- a/src/it/override-war-with-snapshot/war-with-plugin/pom.xml
+++ b/src/it/override-war-with-snapshot/war-with-plugin/pom.xml
@@ -67,7 +67,7 @@
   </profiles>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <revision>1.0.0-SNAPSHOT</revision>
   </properties>
 </project>

--- a/src/it/process-jar/pom.xml
+++ b/src/it/process-jar/pom.xml
@@ -16,7 +16,7 @@
   <name>MyNewPlugin</name>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/process-test-classes/pom.xml
+++ b/src/it/process-test-classes/pom.xml
@@ -23,7 +23,7 @@
     <module>process-test-classes-foo</module>
   </modules>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/snapshot-version-override/pom.xml
+++ b/src/it/snapshot-version-override/pom.xml
@@ -23,7 +23,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/verify-it/pom.xml
+++ b/src/it/verify-it/pom.xml
@@ -40,7 +40,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -44,10 +44,10 @@ Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').
   assert manifest.getMainAttributes().getValue('Extension-Name') == null // was provided by Maven 2, but core prefers Short-Name
   assert manifest.getMainAttributes().getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its')
   assert manifest.getMainAttributes().getValue('Artifact-Id').equals('verify-it')
-  assert manifest.getMainAttributes().getValue('Hudson-Version').equals('2.361.4')
+  assert manifest.getMainAttributes().getValue('Hudson-Version').equals('2.452.4')
   assert manifest.getMainAttributes().getValue('Implementation-Title').equals('MyNewPlugin') // was project.artifactId in previous versions, now project.name
   assert manifest.getMainAttributes().getValue('Implementation-Version').equals('1.0-SNAPSHOT')
-  assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.361.4')
+  assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.452.4')
   assert manifest.getMainAttributes().getValue('Long-Name').equals('MyNewPlugin')
   assert manifest.getMainAttributes().getValue('Manifest-Version').equals('1.0')
   assert manifest.getMainAttributes().getValue('Plugin-Developers').equals('Noam Chomsky:nchomsky:nchomsky@example.com')

--- a/src/it/war-resources/pom.xml
+++ b/src/it/war-resources/pom.xml
@@ -40,7 +40,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.452.4</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- used for filtering -->

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/ValidateMojo.java
@@ -57,8 +57,8 @@ public class ValidateMojo extends AbstractJenkinsMojo {
             }
         }
 
-        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.361")) < 0) {
-            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.361 or later");
+        if (new VersionNumber(findJenkinsVersion()).compareTo(new VersionNumber("2.452")) < 0) {
+            throw new MojoExecutionException("This version of maven-hpi-plugin requires Jenkins 2.452 or later");
         }
 
         MavenProject parent = project.getParent();


### PR DESCRIPTION
Intentionally being somewhat conservative here in case we need to somehow run tip of trunk on older BOM lines (we have before).