### PR TITLE
Revert #21 to allow configuration discovery

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -723,7 +723,6 @@ public class RunMojo extends JettyRunWarMojo {
 
     private void finishConfigurationBeforeStart() {
         WebAppContext wac = getWebAppConfig();
-        wac.setAttribute("org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern", ".*/classes/.*");
         // to allow the development environment to run multiple "mvn hpi:run" with different port,
         // use different session cookie names. Otherwise they can mix up. See
         // http://stackoverflow.com/questions/1612177/are-http-cookies-port-specific


### PR DESCRIPTION
I added this line 10 years ago to address a start-up delay (#21 & https://issues.jenkins.io/browse/JENKINS-30067). However I
need now to remove it in order to allow configuration discovery.

I couldn't notice any significant delay by removing this, so I assume that
the previous delay was caused by a Jetty bug (back in 8.x) that is now
fixed in the Jetty version the Jenkins project uses.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
