### PR TITLE
`TagLibInterfaceGeneratorMojo` fails with `UnsupportedOperationException` on Maven 4.0.0-rc-3

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
@@ -107,7 +107,7 @@ public class TagLibInterfaceGeneratorMojo extends AbstractMojo {
                         }
                     };
             codeModel.build(w);
-            project.getCompileSourceRoots().add(outputDirectory.getAbsolutePath());
+            project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to generate taglib type interface", e);
         } catch (JClassAlreadyExistsException e) {


### PR DESCRIPTION
Fixes #727.

### Testing done

Reproduced the problem on Maven 4 before this PR. Could not longer reproduce after this PR.
Verified that Maven 3 still compiles both before and after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
