### PR TITLE
Bump maven-archiver to pull more recent version of commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
-      <version>3.6.0</version>
+      <version>3.6.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Fix https://github.com/jenkinsci/maven-hpi-plugin/pull/749

By just bumping the version we got a version of commons-compress compatible with current version of API plugin (1.27.1).

Excluding like https://github.com/jenkinsci/maven-hpi-plugin/pull/737 doesn't seems to work (See https://github.com/jenkinsci/maven-hpi-plugin/issues/750#issuecomment-2994028257(

### Testing done

I tested packing and hpi:run on a problematic plugin (Addding `<hpi-plugin.version>3.66-SNAPSHOT</hpi-plugin.version>`). No issue and original issue goes away

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

