### PR TITLE
Reduce log noise from `hpi:resolve-test-dependencies`

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TestDependencyMojo.java
@@ -686,7 +686,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                 }
                 DependencyManagement dm = project.getDependencyManagement();
                 if (dm != null) {
-                    log.info(String.format("Adding dependency management entry %s:%s", key, dependency.getVersion()));
+                    log.debug(String.format("Adding dependency management entry %s:%s", key, dependency.getVersion()));
                     dm.addDependency(dependency);
                 } else {
                     throw new MojoExecutionException(String.format(
@@ -750,9 +750,16 @@ public class TestDependencyMojo extends AbstractHpiMojo {
                     && dependency.getArtifactId().equals(project.getArtifactId())) {
                 throw new MojoExecutionException("Cannot add self as dependency management entry");
             }
-            log.info(String.format("Adding dependency management entry %s:%s", key, version));
+            log.debug(String.format("Adding dependency management entry %s:%s", key, version));
             project.getDependencyManagement().getDependencies().add(dependency);
         }
+
+        log.info("Updated and/or added "
+                + (appliedOverrides.size()
+                        + appliedBundledPlugins.size()
+                        + overrideAdditions.size()
+                        + unappliedBundledPlugins.size())
+                + " direct dependencies and/or dependency management entries");
 
         log.debug("adjusted dependencies: " + project.getDependencies());
         if (project.getDependencyManagement() != null) {
@@ -775,7 +782,7 @@ public class TestDependencyMojo extends AbstractHpiMojo {
         String overrideVersion = overrides.get(key);
         if (overrideVersion != null) {
             String classifier = dependency.getClassifier();
-            log.info(String.format(
+            log.debug(String.format(
                     "Updating %s %s%s from %s to %s",
                     type, key, classifier != null ? ":" + classifier : "", dependency.getVersion(), overrideVersion));
             dependency.setVersion(overrideVersion);


### PR DESCRIPTION
Looking at a recent build of CloudBees CI including PCT runs, I was amazed to see that in a 115Mb log file, >25% of the log lines were `INFO` messages from `hpi:resolve-test-dependencies`. A lot of these were for plugins included in a megawar that are not even in the test classpath of this particular plugin. For example,

```
[INFO] --- hpi:3.61:resolve-test-dependencies (default-cli) @ scm-api ---
…
[INFO] Updating dependency management entry io.jenkins.blueocean:blueocean-rest from 1.27.16 to 1.27.21
[INFO] Updating dependency management entry io.jenkins.blueocean:blueocean-rest-impl from 1.27.16 to 1.27.21
[INFO] Updating dependency management entry io.jenkins.blueocean:blueocean-web from 1.27.16 to 1.27.21
…
[INFO] Updating dependency management entry org.jenkins-ci.plugins.workflow:workflow-api from 1336.vee415d95c521 to 1380.ve03e7a_63d139
[INFO] Updating dependency management entry org.jenkins-ci.plugins.workflow:workflow-api:tests from 1336.vee415d95c521 to 1380.ve03e7a_63d139
…
```

I am changing these log messages to be at `DEBUG` since they might be helpful on occasion to track down some PCT problem with `-X`, but are usually unnecessary; you still get e.g.

```
[INFO] After resolving, additions: {com.fasterxml.jackson.dataformat:jackson-dataformat-csv=2.19.2, com.fasterxml.jackson.dataformat:jackson-dataformat-toml=2.19.2}
[INFO] After resolving, deletions: {org.jenkins-ci.plugins:scm-api=698.v8e3b_c788f0a_6}
[INFO] After resolving, updates: {com.fasterxml.jackson.datatype:jackson-datatype-jdk8=2.19.2, com.fasterxml.jackson.datatype:jackson-datatype-jsr310=2.19.2, org.jenkins-ci.plugins:junit=1335.v6b_a_a_e18534e1, io.jenkins.plugins:jaxb=2.3.9-133.vb_ec76a_73f706, org.jenkins-ci.plugins:jackson2-api=2.19.2-408.v18248a_324cfe, com.fasterxml.jackson.dataformat:jackson-dataformat-cbor=2.19.2, com.fasterxml.jackson.datatype:jackson-datatype-json-org=2.19.2, org.jenkins-ci.plugins.workflow:workflow-api=1380.ve03e7a_63d139, io.jenkins.plugins:jquery3-api=3.7.1-3, com.github.ben-manes.caffeine:caffeine=3.2.2, io.jenkins.plugins:commons-text-api=1.13.1-176.v74d88f22034b_, io.jenkins.plugins:caffeine-api=3.2.2-178.v353b_8428ed56, io.jenkins.plugins:plugin-util-api=6.1.0, org.jenkins-ci.plugins:script-security=1373.vb_b_4a_a_c26fa_00, com.fasterxml.jackson.dataformat:jackson-dataformat-xml=2.19.2, org.jboss.marshalling:jboss-marshalling-river=2.2.2.Final, org.jenkins-ci.plugins.workflow:workflow-support=968.v8f17397e87b_8, org.ow2.asm:asm-analysis=9.8, io.jenkins.plugins:asm-api=9.8-163.vb_2a_96d3f9c3c, com.fasterxml.jackson.module:jackson-module-parameter-names=2.19.2, io.jenkins.plugins:checks-api=373.vfe7645102093, org.ow2.asm:asm-tree=9.8, com.fasterxml.woodstox:woodstox-core=7.1.1, org.jenkins-ci.plugins:structs=350.v3b_30f09f2363, io.jenkins.plugins:echarts-api=5.6.0-5, io.jenkins.plugins:commons-lang3-api=3.18.0-98.v3a_674c06072d, io.jenkins.plugins:ionicons-api=88.va_4187cb_eddf1, com.fasterxml.jackson.dataformat:jackson-dataformat-yaml=2.19.2, io.jenkins.plugins:font-awesome-api=7.0.0-1, org.jboss.marshalling:jboss-marshalling=2.2.2.Final, org.apache.commons:commons-lang3=3.18.0, com.fasterxml.jackson.core:jackson-databind=2.19.2, com.fasterxml.jackson.core:jackson-annotations=2.19.2, com.fasterxml.jackson.core:jackson-core=2.19.2, io.jenkins.plugins:snakeyaml-api=2.3-125.v4d77857a_b_402, io.jenkins.plugins:javax-activation-api=1.2.0-8, com.fasterxml.jackson.module:jackson-module-jaxb-annotations=2.19.2, io.jenkins.plugins:json-api=20250517-153.vc8a_a_d87c0ce3, org.json:json=20250517, org.ow2.asm:asm-commons=9.8, org.apache.commons:commons-text=1.13.1, io.jenkins.plugins:bootstrap5-api=5.3.7-1, org.jenkins-ci.plugins.workflow:workflow-step-api=704.ve4f0967e98fa_, org.ow2.asm:asm-util=9.8}
```

which is mostly what you need to know when looking at a PCT failure.
