### PR TITLE
Fix port property description in `run` mojo documentation

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -104,7 +104,7 @@ import sun.misc.Unsafe;
  * </p>
  *
  * <p>
- * To specify the HTTP port, use {@code -Djetty.port=PORT}
+ * To specify the HTTP port, use {@code -Dport=PORT}
  * </p>
  *
  * @author Kohsuke Kawaguchi


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The documentation is wrong: the HTTP [port](https://github.com/jenkinsci/maven-hpi-plugin/blob/948ffad3d078346bb5a11a561e9b437e7f40f4ed/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java#L176) can be customized using `port` system property (`jetty.port` no longer works).


### Testing done

Confirmed that `mvn -Dport=9090 hpi:run` listens on port 9090 and that `mvn -Djetty.port=9090 hpi:run` does not listen on port 9090

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed