### PR TITLE
Fix javadoc link and add `@since` versions for strict bundled artifact properties

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -220,7 +220,7 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
     /**
      * If {@code true}, then if {@link #bundledArtifacts} does not match the actual list of
      * bundled artifacts, the build will fail.
-     * @since TODO
+     * @since 3.1746.v2e9fe7dc4d95
      */
     @Parameter(defaultValue = "${hpi.strictBundledArtifacts}")
     private boolean strictBundledArtifacts;
@@ -229,8 +229,8 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
      * A list of comma-separated Maven artifact IDs that correspond to Jar files that are expected
      * to be bundled in the plugin's HPI file.
      * If this list does not match the actual bundled artifacts, the build will either fail if
-     * {@link #strictBundledArtifactsCheck} is enabled, or a warning will be logged otherwise.
-     * @since TODO
+     * {@link #strictBundledArtifacts} is enabled, or a warning will be logged otherwise.
+     * @since 3.1746.v2e9fe7dc4d95
      */
     @Parameter(defaultValue = "${hpi.bundledArtifacts}")
     private List<String> bundledArtifacts;


### PR DESCRIPTION
While looking at https://jenkinsci.github.io/maven-hpi-plugin/hpi-mojo.html for the new properties related to https://github.com/jenkinsci/maven-hpi-plugin/issues/557, I noticed a bad Javadoc link and that the `since: TODO` placeholders from #771 can now be filled in. 

### Testing done

I ran the ITs locally and they still pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
