### PR TITLE
Support dots in Jelly file names

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/TagLibInterfaceGeneratorMojo.java
@@ -158,7 +158,7 @@ public class TagLibInterfaceGeneratorMojo extends AbstractMojo {
                         String baseName = FilenameUtils.getBaseName(tag.getName());
                         String methodName;
                         if (!JJavaName.isJavaIdentifier(tag.getName())) {
-                            methodName = baseName.replace('-', '_');
+                            methodName = baseName.replaceAll("[.-]", "_");
                             if (ReservedName.NAMES.contains(methodName)) {
                                 methodName += '_';
                             }


### PR DESCRIPTION
Experimenting with a component at the moment, titled `defer.placeholder`. Having a `.` is invalid at the moment when converted to Java - so I've updated this to rename the dot to an underscore (same way it handled hyphens).

### Testing done

* Jenkins builds successfully with this change (previously it didn't) for https://github.com/jenkinsci/jenkins/pull/11222

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
