### PR TITLE
Re-enable test injection in integration tests

### DIFF
--- a/src/it/JENKINS-45740-metadata/pom.xml
+++ b/src/it/JENKINS-45740-metadata/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -34,13 +34,12 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!--Examples of real use-cases-->
     <hpi.pluginChangelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChangelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/configuration-as-code-plugin/master/plugin/src/main/webapp/img/logo-head.svg</hpi.pluginLogoUrl>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <repositories>

--- a/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -14,18 +14,17 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.452.x</artifactId>
-        <version>3010.vec758b_8e7da_3</version>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins-3/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -14,18 +14,17 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.452.x</artifactId>
-        <version>3010.vec758b_8e7da_3</version>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>4228.v0a_71308d905b_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/JENKINS-58771-packaged-plugins/pom.xml
+++ b/src/it/JENKINS-58771-packaged-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -14,18 +14,17 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.452.x</artifactId>
-        <version>3010.vec758b_8e7da_3</version>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/java-level/pom.xml
+++ b/src/it/java-level/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -13,10 +13,9 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
-    <java.level>11</java.level>
+    <jenkins.version>2.479.3</jenkins.version>
+    <java.level>17</java.level>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 </project>

--- a/src/it/metadata-it/pom.xml
+++ b/src/it/metadata-it/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -34,10 +34,9 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <gitHubRepo>jenkinsci/maven-hpi-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 </project>

--- a/src/it/metadata-it/verify.groovy
+++ b/src/it/metadata-it/verify.groovy
@@ -14,8 +14,8 @@ try (JarFile j1 = new JarFile(p1)) {
     // there may be other attribute like 'Created-By' that we do not care about we are not checking everything
     assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
 
-    assert attributes.getValue('Hudson-Version').equals('2.452.4')
-    assert attributes.getValue('Jenkins-Version').equals('2.452.4')
+    assert attributes.getValue('Hudson-Version').equals('2.479.3')
+    assert attributes.getValue('Jenkins-Version').equals('2.479.3')
 
     assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
     assert attributes.getValue('Artifact-Id').equals('plugin1')
@@ -48,8 +48,8 @@ try (JarFile j2 = new JarFile(p2)) {
     Attributes attributes = mf.getMainAttributes()
     assert attributes.getValue('Manifest-Version').equals('1.0') // if this changes then Jenkins may not be able to parse it.
 
-    assert attributes.getValue('Hudson-Version').equals('2.452.4')
-    assert attributes.getValue('Jenkins-Version').equals('2.452.4')
+    assert attributes.getValue('Hudson-Version').equals('2.479.3')
+    assert attributes.getValue('Jenkins-Version').equals('2.479.3')
 
     assert attributes.getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its.git-metadata')
     assert attributes.getValue('Artifact-Id').equals('multimodule-it-plugin2')

--- a/src/it/minimum-java-version/pom.xml
+++ b/src/it/minimum-java-version/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -13,10 +13,9 @@
   <packaging>hpi</packaging>
   <name>MyNewPlugin</name>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <build>
     <plugins>

--- a/src/it/missing-index/pom.xml
+++ b/src/it/missing-index/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -14,9 +14,8 @@
   <name>MyNewPlugin</name>
   <description>Deprecated spot for plugin description.</description>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 </project>

--- a/src/it/override-test-dependencies-release-failure/pom.xml
+++ b/src/it/override-test-dependencies-release-failure/pom.xml
@@ -4,17 +4,16 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <artifactId>check-core-version-failure</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/override-test-dependencies-smokes/pom.xml
+++ b/src/it/override-test-dependencies-smokes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <!-- TODO cannot include `invoker.goals=-DoverrideVersions=…,… test` in invoker.properties since then that is misinterpreted as multiple arguments for invoker.goals -->
     <overrideVersions>org.jenkins-ci.plugins.workflow:workflow-step-api:2.11,org.jenkins-ci.plugins.workflow:workflow-api:2.17,org.jenkins-ci.plugins.workflow:workflow-cps:2.32</overrideVersions>
@@ -21,7 +21,6 @@
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <workflow-step-api-plugin.version>2.9</workflow-step-api-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/override-test-dependencies-split-plugin/pom.xml
+++ b/src/it/override-test-dependencies-split-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.3</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -12,10 +12,9 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.479.2</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/override-war-with-snapshot/dependant/pom.xml
+++ b/src/it/override-war-with-snapshot/dependant/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -47,7 +47,6 @@
     </dependency>
   </dependencies>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+    <jenkins.version>2.479.3</jenkins.version>
   </properties>
 </project>

--- a/src/it/override-war-with-snapshot/war-with-plugin/pom.xml
+++ b/src/it/override-war-with-snapshot/war-with-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -67,8 +67,7 @@
   </profiles>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <revision>1.0.0-SNAPSHOT</revision>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 </project>

--- a/src/it/parent-4x/pom.xml
+++ b/src/it/parent-4x/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.2</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -12,11 +12,10 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.479.1</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <no-test-jar>false</no-test-jar>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/parent-4x/verify.groovy
+++ b/src/it/parent-4x/verify.groovy
@@ -25,7 +25,7 @@ checkArtifact(installed, 'parent-4x-1.0-SNAPSHOT.hpi',
     ['WEB-INF/lib/parent-4x.jar'],
     // TODO still some problems with unwanted transitive JAR dependencies creeping in, e.g. WEB-INF/lib/jboss-marshalling-1.4.9.Final.jar in workflow-multibranch.hpi, or all kinds of junk in parameterized-trigger.hpi
     ['test/SampleRootAction.class', 'WEB-INF/lib/symbol-annotation-1.5.jar'],
-    ['Short-Name': 'parent-4x', 'Group-Id': 'org.jenkins-ci.tools.hpi.its', 'Jenkins-Version': '2.479.1' /* Plugin-Version unpredictable for a snapshot */, 'Plugin-Dependencies': 'structs:338.v848422169819'])
+    ['Short-Name': 'parent-4x', 'Group-Id': 'org.jenkins-ci.tools.hpi.its', 'Jenkins-Version': '2.479.3' /* Plugin-Version unpredictable for a snapshot */, 'Plugin-Dependencies': 'structs:338.v848422169819'])
 
 checkArtifact(installed, 'parent-4x-1.0-SNAPSHOT.jar',
     ['META-INF/annotations/hudson.Extension', 'test/SampleRootAction.class', 'index.jelly'],

--- a/src/it/process-jar/pom.xml
+++ b/src/it/process-jar/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -16,10 +16,9 @@
   <name>MyNewPlugin</name>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/process-test-classes/pom.xml
+++ b/src/it/process-test-classes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.tools.hpi.its</groupId>
@@ -23,10 +23,9 @@
     <module>process-test-classes-foo</module>
   </modules>
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
   <repositories>
     <repository>

--- a/src/it/snapshot-version-override/pom.xml
+++ b/src/it/snapshot-version-override/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -23,10 +23,9 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <build>

--- a/src/it/strict-bundled-artifacts-extra/pom.xml
+++ b/src/it/strict-bundled-artifacts-extra/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,6 @@
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- slf4j-api is listed here but is not actually bundled -->
     <hpi.bundledArtifacts>metrics-core,metrics-json,slf4j-api</hpi.bundledArtifacts>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/strict-bundled-artifacts-missing-warning/pom.xml
+++ b/src/it/strict-bundled-artifacts-missing-warning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -19,7 +19,6 @@
     <spotless.check.skip>false</spotless.check.skip>
     <!-- jackson-annotations, jackson-core, and jackson-databind are bundled but not listed here -->
     <hpi.bundledArtifacts>metrics-core,metrics-json</hpi.bundledArtifacts>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/strict-bundled-artifacts-missing/pom.xml
+++ b/src/it/strict-bundled-artifacts-missing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,6 @@
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- jackson-annotations, jackson-core, and jackson-databind are bundled but not listed here -->
     <hpi.bundledArtifacts>metrics-core,metrics-json</hpi.bundledArtifacts>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/strict-bundled-artifacts-sort/pom.xml
+++ b/src/it/strict-bundled-artifacts-sort/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -19,7 +19,6 @@
     <spotless.check.skip>false</spotless.check.skip>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <hpi.bundledArtifacts>metrics-json,metrics-core</hpi.bundledArtifacts>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/strict-bundled-artifacts-success/pom.xml
+++ b/src/it/strict-bundled-artifacts-success/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -19,7 +19,6 @@
     <spotless.check.skip>false</spotless.check.skip>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <hpi.bundledArtifacts>metrics-core,metrics-json</hpi.bundledArtifacts>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 
   <dependencies>

--- a/src/it/verify-it/pom.xml
+++ b/src/it/verify-it/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -40,9 +40,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>
 </project>

--- a/src/it/verify-it/verify.groovy
+++ b/src/it/verify-it/verify.groovy
@@ -44,10 +44,10 @@ Files.newInputStream(new File(basedir, 'target/verify-it/META-INF/MANIFEST.MF').
   assert manifest.getMainAttributes().getValue('Extension-Name') == null // was provided by Maven 2, but core prefers Short-Name
   assert manifest.getMainAttributes().getValue('Group-Id').equals('org.jenkins-ci.tools.hpi.its')
   assert manifest.getMainAttributes().getValue('Artifact-Id').equals('verify-it')
-  assert manifest.getMainAttributes().getValue('Hudson-Version').equals('2.452.4')
+  assert manifest.getMainAttributes().getValue('Hudson-Version').equals('2.479.3')
   assert manifest.getMainAttributes().getValue('Implementation-Title').equals('MyNewPlugin') // was project.artifactId in previous versions, now project.name
   assert manifest.getMainAttributes().getValue('Implementation-Version').equals('1.0-SNAPSHOT')
-  assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.452.4')
+  assert manifest.getMainAttributes().getValue('Jenkins-Version').equals('2.479.3')
   assert manifest.getMainAttributes().getValue('Long-Name').equals('MyNewPlugin')
   assert manifest.getMainAttributes().getValue('Manifest-Version').equals('1.0')
   assert manifest.getMainAttributes().getValue('Plugin-Developers').equals('Noam Chomsky:nchomsky:nchomsky@example.com')

--- a/src/it/war-resources/pom.xml
+++ b/src/it/war-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.2098.v4d48a_c4c68e7</version>
     <relativePath />
   </parent>
 
@@ -40,10 +40,9 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <hpi-plugin.version>@project.version@</hpi-plugin.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     <!-- used for filtering -->
     <prop1>hello</prop1>
     <prop2>goodbye</prop2>


### PR DESCRIPTION
Ameds #846 / https://github.com/jenkinsci/maven-hpi-plugin/pull/846#issuecomment-3657900357

* Upgrade failing tests to plugin-pom 5.2098.v4d48a_c4c68e7
* Bump jenkins version to 2.479.3 if required

<!-- Please describe your pull request here. -->

### Testing done

`mvn clean verify -Prun-its`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
