### PR TITLE
pick up newer plexus-archiver to prevent OOM when building hpis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <!-- 4.10.2 transitve dep of maven-archiver has memory issues
-          https://github.com/codehaus-plexus/plexus-archiver/issues/399 -->
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-archiver</artifactId>
-        <version>4.10.4</version>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
         <version>${jetty.version}</version>
@@ -166,6 +159,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
+      <!-- revert the plexus archiver override if updating this https://github.com/apache/maven-archiver/issues/334 -->
       <version>3.6.5</version>
     </dependency>
     <dependency>
@@ -183,6 +177,15 @@
           <artifactId>plexus-interpolation</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <!-- 4.10.2 transitve dep of maven-archiver has memory issues
+          https://github.com/codehaus-plexus/plexus-archiver/issues/399 
+          unfortunately dependencyManagement does not work and we need to promote this to a direct dep
+          -->
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>4.10.4</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Prevent excessive memory usage whilst assembling the HPI.
pickup https://github.com/codehaus-plexus/plexus-archiver/issues/399 to fix the issue (transitive dependency of maven-archiver) https://github.com/apache/maven-archiver/issues/334


### Testing done

builds that where constantly failing where updated to use a SNPSHOT build of this PR.
validated they now do not fail with OutOfMemoryErrors 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
