### PR TITLE
Default debug port to 5005

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java
@@ -122,6 +122,14 @@ public class RunMojo extends AbstractHpiMojo {
     private String debugForkedProcess;
 
     /**
+     * Port number for the debugger to attach to.
+     * <p>
+     * Not used if <code>maven.hpi.debug</code> is specified with a custom debug value.
+     */
+    @Parameter(property = "maven.hpi.debug.port", defaultValue = "5005")
+    protected int debugPort;
+
+    /**
      * Specifies the HTTP port number.
      * <p>
      * If connectors are configured in the Mojo, that'll take precedence.
@@ -358,7 +366,7 @@ public class RunMojo extends AbstractHpiMojo {
         cmd.add(javaExe);
 
         if (isDebuggerPresent() || "true".equalsIgnoreCase(debugForkedProcess)) {
-            cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0");
+            cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + debugPort);
         } else if (debugForkedProcess != null && !debugForkedProcess.isBlank()) {
             cmd.add(debugForkedProcess.trim());
         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

see https://github.com/jenkinsci/maven-hpi-plugin/pull/862#discussion_r2724152881

Why 5005? Its the default port for IntelliJ debug run configurations, so no need to change it when you create a remote debug configuration.

### Testing done

Checked it starts on 5005 and that I can customise it

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
