### PR TITLE
Enforcer rule for obsolete dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <dependency>
       <groupId>org.apache.maven.enforcer</groupId>
       <artifactId>enforcer-api</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.enforcer</groupId>
+      <artifactId>enforcer-api</artifactId>
+      <version>3.5.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven-plugin-tools.version}</version>

--- a/src/it/bom-obsolete-override-both-types/invoker.properties
+++ b/src/it/bom-obsolete-override-both-types/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-both-types/pom.xml
+++ b/src/it/bom-obsolete-override-both-types/pom.xml
@@ -55,7 +55,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-both-types/pom.xml
+++ b/src/it/bom-obsolete-override-both-types/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-both-types</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Both Types</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <!-- Override with OLDER version than parent - should fail -->
+    <jenkins-test-harness.version>2535.va_83a_c5b_19a_89</jenkins-test-harness.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version OLDER than BOM - should also fail -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-both-types/verify.groovy
+++ b/src/it/bom-obsolete-override-both-types/verify.groovy
@@ -1,0 +1,10 @@
+// Build should fail due to BOTH obsolete dependency and property overrides
+def log = new File(basedir, 'build.log').getText('UTF-8')
+// Check for dependency violations
+assert log.contains('Found obsolete dependency version overrides')
+assert log.contains('org.jenkins-ci.plugins:credentials: declared 1.200 < 1415.v831096eb_5534 from imported BOM bom-2.479.x')
+// Check for property violations
+assert log.contains('Found obsolete property overrides')
+assert log.contains('jenkins-test-harness.version')
+assert log.contains('declared 2535.va_83a_c5b_19a_89 < 2537.v48fd29a_7070d from parent POM')
+return true

--- a/src/it/bom-obsolete-override-equal-version/invoker.properties
+++ b/src/it/bom-obsolete-override-equal-version/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-equal-version/pom.xml
+++ b/src/it/bom-obsolete-override-equal-version/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-equal-version</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Equal Version</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version EQUAL to BOM (1415.v831096eb_5534) - should fail -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1415.v831096eb_5534</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-equal-version/pom.xml
+++ b/src/it/bom-obsolete-override-equal-version/pom.xml
@@ -53,7 +53,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-equal-version/verify.groovy
+++ b/src/it/bom-obsolete-override-equal-version/verify.groovy
@@ -1,0 +1,6 @@
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Found obsolete dependency version overrides')
+assert log.contains('older than or equal to')
+assert log.contains('org.jenkins-ci.plugins:credentials')
+assert log.contains('1415.v831096eb_5534')
+return true

--- a/src/it/bom-obsolete-override-fail-multiple/invoker.properties
+++ b/src/it/bom-obsolete-override-fail-multiple/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-fail-multiple/pom.xml
+++ b/src/it/bom-obsolete-override-fail-multiple/pom.xml
@@ -63,7 +63,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-fail-multiple/pom.xml
+++ b/src/it/bom-obsolete-override-fail-multiple/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-fail-multiple</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Fail Multiple</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Multiple overrides with versions OLDER than BOM - should fail with all listed -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+        <version>1.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-support</artifactId>
+        <version>1.100</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-fail-multiple/verify.groovy
+++ b/src/it/bom-obsolete-override-fail-multiple/verify.groovy
@@ -1,0 +1,8 @@
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Found obsolete dependency version overrides')
+// Verify all three dependencies are reported in the same failure message
+assert log.contains('org.jenkins-ci.plugins:credentials')
+assert log.contains('org.jenkins-ci.plugins.workflow:workflow-api')
+assert log.contains('org.jenkins-ci.plugins.workflow:workflow-support')
+assert log.contains('bom-2.479.x')
+return true

--- a/src/it/bom-obsolete-override-fail-single/invoker.properties
+++ b/src/it/bom-obsolete-override-fail-single/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-fail-single/pom.xml
+++ b/src/it/bom-obsolete-override-fail-single/pom.xml
@@ -37,7 +37,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.2</version>
         <dependencies>
           <dependency>
             <groupId>org.jenkins-ci.tools</groupId>

--- a/src/it/bom-obsolete-override-fail-single/pom.xml
+++ b/src/it/bom-obsolete-override-fail-single/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-fail-single</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Fail Single</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version OLDER than BOM (1.276.v99a_de03cb_076) - should fail -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-fail-single/pom.xml
+++ b/src/it/bom-obsolete-override-fail-single/pom.xml
@@ -53,7 +53,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-fail-single/verify.groovy
+++ b/src/it/bom-obsolete-override-fail-single/verify.groovy
@@ -1,0 +1,6 @@
+// Build should fail due to obsolete override
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Found obsolete dependency version overrides')
+assert log.contains('org.jenkins-ci.plugins:credentials')
+assert log.contains('bom-2.479.x')
+return true

--- a/src/it/bom-obsolete-override-multimodule/child/pom.xml
+++ b/src/it/bom-obsolete-override-multimodule/child/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+    <artifactId>bom-obsolete-override-multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>bom-obsolete-override-multimodule-child</artifactId>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Multimodule Child</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/bom-obsolete-override-multimodule/invoker.properties
+++ b/src/it/bom-obsolete-override-multimodule/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-multimodule/pom.xml
+++ b/src/it/bom-obsolete-override-multimodule/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-multimodule</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Test Plugin - BOM Obsolete Override Multimodule Parent</name>
+  <modules>
+    <module>child</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version OLDER than BOM - should fail when enforcer runs on parent -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-multimodule/pom.xml
+++ b/src/it/bom-obsolete-override-multimodule/pom.xml
@@ -56,7 +56,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-multimodule/verify.groovy
+++ b/src/it/bom-obsolete-override-multimodule/verify.groovy
@@ -1,0 +1,9 @@
+// Build should fail due to obsolete override in parent POM
+// The enforcer runs on the parent module before processing the child
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Found obsolete dependency version overrides')
+assert log.contains('org.jenkins-ci.plugins:credentials')
+assert log.contains('bom-2.479.x')
+// Verify the failure happened during parent processing, not child
+assert log.contains('Building Test Plugin - BOM Obsolete Override Multimodule Parent')
+return true

--- a/src/it/bom-obsolete-override-no-boms/invoker.properties
+++ b/src/it/bom-obsolete-override-no-boms/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-no-boms/pom.xml
+++ b/src/it/bom-obsolete-override-no-boms/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-no-boms</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override No BOMs</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- No BOM imports, just direct version management - should pass (nothing to check) -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-no-boms/pom.xml
+++ b/src/it/bom-obsolete-override-no-boms/pom.xml
@@ -46,7 +46,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-no-boms/verify.groovy
+++ b/src/it/bom-obsolete-override-no-boms/verify.groovy
@@ -1,5 +1,5 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
 // Build should pass - no BOMs means no BOM-related violations to check
 // Property check still runs but finds no violations
-assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
 return true

--- a/src/it/bom-obsolete-override-no-boms/verify.groovy
+++ b/src/it/bom-obsolete-override-no-boms/verify.groovy
@@ -1,5 +1,5 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
 // Build should pass - no BOMs means no BOM-related violations to check
 // Property check still runs but finds no violations
-assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.BanObsoleteDependencyOverrides passed')
 return true

--- a/src/it/bom-obsolete-override-no-boms/verify.groovy
+++ b/src/it/bom-obsolete-override-no-boms/verify.groovy
@@ -1,0 +1,3 @@
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('No imported BOMs found')
+return true

--- a/src/it/bom-obsolete-override-no-boms/verify.groovy
+++ b/src/it/bom-obsolete-override-no-boms/verify.groovy
@@ -1,3 +1,5 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('No imported BOMs found')
+// Build should pass - no BOMs means no BOM-related violations to check
+// Property check still runs but finds no violations
+assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
 return true

--- a/src/it/bom-obsolete-override-no-explicit-versions/invoker.properties
+++ b/src/it/bom-obsolete-override-no-explicit-versions/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-no-explicit-versions/pom.xml
+++ b/src/it/bom-obsolete-override-no-explicit-versions/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-no-explicit-versions</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override No Explicit Versions</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Dependencies declared without explicit versions (rely on BOM) - should pass -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-no-explicit-versions/pom.xml
+++ b/src/it/bom-obsolete-override-no-explicit-versions/pom.xml
@@ -56,7 +56,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
+++ b/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
@@ -1,3 +1,3 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.BanObsoleteDependencyOverrides passed')
 return true

--- a/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
+++ b/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
@@ -1,3 +1,3 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('No obsolete overrides found')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
 return true

--- a/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
+++ b/src/it/bom-obsolete-override-no-explicit-versions/verify.groovy
@@ -1,0 +1,3 @@
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('No obsolete overrides found')
+return true

--- a/src/it/bom-obsolete-override-pass/invoker.properties
+++ b/src/it/bom-obsolete-override-pass/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-pass/pom.xml
+++ b/src/it/bom-obsolete-override-pass/pom.xml
@@ -37,7 +37,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.2</version>
         <dependencies>
           <dependency>
             <groupId>org.jenkins-ci.tools</groupId>

--- a/src/it/bom-obsolete-override-pass/pom.xml
+++ b/src/it/bom-obsolete-override-pass/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-pass</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Pass</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version NEWER than BOM (1.276.v99a_de03cb_076) - should pass -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>99999.v999999999999</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-pass/pom.xml
+++ b/src/it/bom-obsolete-override-pass/pom.xml
@@ -53,7 +53,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-pass/verify.groovy
+++ b/src/it/bom-obsolete-override-pass/verify.groovy
@@ -1,0 +1,3 @@
+// Build should succeed - newer version override is allowed
+assert new File(basedir, 'build.log').exists()
+return true

--- a/src/it/bom-obsolete-override-pass/verify.groovy
+++ b/src/it/bom-obsolete-override-pass/verify.groovy
@@ -1,5 +1,5 @@
 // Build should succeed - newer version override is allowed
 def buildLog = new File(basedir, 'build.log')
 assert buildLog.exists()
-assert buildLog.text.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
+assert buildLog.text.contains('org.jenkinsci.maven.plugins.hpi.enforcer.BanObsoleteDependencyOverrides passed')
 return true

--- a/src/it/bom-obsolete-override-pass/verify.groovy
+++ b/src/it/bom-obsolete-override-pass/verify.groovy
@@ -1,5 +1,5 @@
 // Build should succeed - newer version override is allowed
 def buildLog = new File(basedir, 'build.log')
 assert buildLog.exists()
-assert buildLog.text.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+assert buildLog.text.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
 return true

--- a/src/it/bom-obsolete-override-pass/verify.groovy
+++ b/src/it/bom-obsolete-override-pass/verify.groovy
@@ -1,3 +1,5 @@
 // Build should succeed - newer version override is allowed
-assert new File(basedir, 'build.log').exists()
+def buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+assert buildLog.text.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
 return true

--- a/src/it/bom-obsolete-override-property-newer/invoker.properties
+++ b/src/it/bom-obsolete-override-property-newer/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-property-newer/pom.xml
+++ b/src/it/bom-obsolete-override-property-newer/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-property-newer</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Property Newer</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <!-- Override with NEWER version than parent - should pass (valid override) -->
+    <jenkins-test-harness.version>2565.vd1eb_7c961d1b_</jenkins-test-harness.version>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-property-newer/pom.xml
+++ b/src/it/bom-obsolete-override-property-newer/pom.xml
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-property-newer/verify.groovy
+++ b/src/it/bom-obsolete-override-property-newer/verify.groovy
@@ -1,0 +1,6 @@
+// Build should pass - property override is newer than parent (valid override)
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+// Should NOT contain property violations
+assert !log.contains('Found obsolete property overrides')
+return true

--- a/src/it/bom-obsolete-override-property-newer/verify.groovy
+++ b/src/it/bom-obsolete-override-property-newer/verify.groovy
@@ -1,6 +1,6 @@
 // Build should pass - property override is newer than parent (valid override)
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
 // Should NOT contain property violations
 assert !log.contains('Found obsolete property overrides')
 return true

--- a/src/it/bom-obsolete-override-property-newer/verify.groovy
+++ b/src/it/bom-obsolete-override-property-newer/verify.groovy
@@ -1,6 +1,6 @@
 // Build should pass - property override is newer than parent (valid override)
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.BanObsoleteDependencyOverrides passed')
 // Should NOT contain property violations
 assert !log.contains('Found obsolete property overrides')
 return true

--- a/src/it/bom-obsolete-override-property-only/invoker.properties
+++ b/src/it/bom-obsolete-override-property-only/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-ntp validate
+invoker.buildResult=failure

--- a/src/it/bom-obsolete-override-property-only/pom.xml
+++ b/src/it/bom-obsolete-override-property-only/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-property-only</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Property Only</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <!-- Override with SAME version as parent plugin-pom - also a violation (unnecessary override) -->
+    <jenkins-test-harness.version>2537.v48fd29a_7070d</jenkins-test-harness.version>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-property-only/pom.xml
+++ b/src/it/bom-obsolete-override-property-only/pom.xml
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-property-only/verify.groovy
+++ b/src/it/bom-obsolete-override-property-only/verify.groovy
@@ -1,0 +1,8 @@
+// Build should fail due to obsolete property override (equal version - unnecessary override)
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Found obsolete property overrides')
+assert log.contains('jenkins-test-harness.version')
+assert log.contains('declared 2537.v48fd29a_7070d == 2537.v48fd29a_7070d from parent POM')
+// Should NOT contain dependency violations
+assert !log.contains('Found obsolete dependency version overrides')
+return true

--- a/src/it/bom-obsolete-override-property-placeholder/invoker.properties
+++ b/src/it/bom-obsolete-override-property-placeholder/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-property-placeholder/pom.xml
+++ b/src/it/bom-obsolete-override-property-placeholder/pom.xml
@@ -49,7 +49,7 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement />
+                <banObsoleteDependencyOverrides />
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-property-placeholder/pom.xml
+++ b/src/it/bom-obsolete-override-property-placeholder/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-property-placeholder</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Property Placeholder</name>
+  <properties>
+    <!-- Recommended pattern for Jenkins OSS plugins -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-property-placeholder/verify.groovy
+++ b/src/it/bom-obsolete-override-property-placeholder/verify.groovy
@@ -1,7 +1,7 @@
 // Build should pass - jenkins.version uses ${jenkins.baseline} placeholder (recommended pattern)
 // Rule should resolve ${jenkins.baseline}.3 to 2.479.3 before comparison
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
 // Should NOT report jenkins.version as obsolete
 assert !log.contains('Found obsolete property overrides')
 return true

--- a/src/it/bom-obsolete-override-property-placeholder/verify.groovy
+++ b/src/it/bom-obsolete-override-property-placeholder/verify.groovy
@@ -1,0 +1,7 @@
+// Build should pass - jenkins.version uses ${jenkins.baseline} placeholder (recommended pattern)
+// Rule should resolve ${jenkins.baseline}.3 to 2.479.3 before comparison
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('[RequireNonObsoleteDependencyManagement] No obsolete overrides found')
+// Should NOT report jenkins.version as obsolete
+assert !log.contains('Found obsolete property overrides')
+return true

--- a/src/it/bom-obsolete-override-property-placeholder/verify.groovy
+++ b/src/it/bom-obsolete-override-property-placeholder/verify.groovy
@@ -1,7 +1,7 @@
 // Build should pass - jenkins.version uses ${jenkins.baseline} placeholder (recommended pattern)
 // Rule should resolve ${jenkins.baseline}.3 to 2.479.3 before comparison
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.RequireNonObsoleteDependencyManagement passed')
+assert log.contains('org.jenkinsci.maven.plugins.hpi.enforcer.BanObsoleteDependencyOverrides passed')
 // Should NOT report jenkins.version as obsolete
 assert !log.contains('Found obsolete property overrides')
 return true

--- a/src/it/bom-obsolete-override-skip/invoker.properties
+++ b/src/it/bom-obsolete-override-skip/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-ntp validate

--- a/src/it/bom-obsolete-override-skip/pom.xml
+++ b/src/it/bom-obsolete-override-skip/pom.xml
@@ -53,9 +53,9 @@
             </goals>
             <configuration>
               <rules>
-                <requireNonObsoleteDependencyManagement>
+                <banObsoleteDependencyOverrides>
                   <skip>true</skip>
-                </requireNonObsoleteDependencyManagement>
+                </banObsoleteDependencyOverrides>
               </rules>
             </configuration>
           </execution>

--- a/src/it/bom-obsolete-override-skip/pom.xml
+++ b/src/it/bom-obsolete-override-skip/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.2098.v4d48a_c4c68e7</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.tools.hpi.its</groupId>
+  <artifactId>bom-obsolete-override-skip</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>Test Plugin - BOM Obsolete Override Skip</name>
+  <properties>
+    <jenkins.version>2.479.3</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override with version OLDER than BOM but skip=true - should pass -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.200</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>check-obsolete-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireNonObsoleteDependencyManagement>
+                  <skip>true</skip>
+                </requireNonObsoleteDependencyManagement>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/bom-obsolete-override-skip/verify.groovy
+++ b/src/it/bom-obsolete-override-skip/verify.groovy
@@ -1,3 +1,3 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('requireNonObsoleteDependencyManagement skipped')
+assert log.contains('banObsoleteDependencyOverrides skipped')
 return true

--- a/src/it/bom-obsolete-override-skip/verify.groovy
+++ b/src/it/bom-obsolete-override-skip/verify.groovy
@@ -1,0 +1,3 @@
+def log = new File(basedir, 'build.log').getText('UTF-8')
+assert log.contains('Skipping RequireNonObsoleteDependencyManagement rule')
+return true

--- a/src/it/bom-obsolete-override-skip/verify.groovy
+++ b/src/it/bom-obsolete-override-skip/verify.groovy
@@ -1,3 +1,3 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('[RequireNonObsoleteDependencyManagement] Skipping rule')
+assert log.contains('requireNonObsoleteDependencyManagement skipped')
 return true

--- a/src/it/bom-obsolete-override-skip/verify.groovy
+++ b/src/it/bom-obsolete-override-skip/verify.groovy
@@ -1,3 +1,3 @@
 def log = new File(basedir, 'build.log').getText('UTF-8')
-assert log.contains('Skipping RequireNonObsoleteDependencyManagement rule')
+assert log.contains('[RequireNonObsoleteDependencyManagement] Skipping rule')
 return true

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BanObsoleteDependencyOverrides.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BanObsoleteDependencyOverrides.java
@@ -16,11 +16,12 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.project.MavenProject;
 
 /**
- * Maven Enforcer rule that detects obsolete dependency version overrides in {@code <dependencyManagement>}.
+ * Maven Enforcer rule that bans obsolete dependency and property overrides.
  * <p>
  * This rule fails the build when {@code <dependencyManagement>} specifies versions for dependencies that are
- * older than or equal to versions provided by imported BOMs. This helps identify unnecessary overrides that
- * can be removed when updating BOM versions.
+ * older than or equal to versions provided by imported BOMs, or when {@code <properties>} override {@code *.version}
+ * properties with values older than or equal to those in the parent POM. This helps identify unnecessary overrides
+ * that can be removed when updating BOM versions or parent POMs.
  * </p>
  * <p>
  * Example usage in a POM:
@@ -35,7 +36,7 @@ import org.apache.maven.project.MavenProject;
  *           <goals><goal>enforce</goal></goals>
  *           <configuration>
  *             <rules>
- *               <requireNonObsoleteDependencyManagement/>
+ *               <banObsoleteDependencyOverrides/>
  *             </rules>
  *           </configuration>
  *         </execution>
@@ -45,8 +46,8 @@ import org.apache.maven.project.MavenProject;
  * </build>
  * }</pre>
  */
-@Named("requireNonObsoleteDependencyManagement")
-public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule {
+@Named("banObsoleteDependencyOverrides")
+public class BanObsoleteDependencyOverrides extends AbstractEnforcerRule {
 
     private final MavenProject project;
     private final BomResolverUtil bomResolverUtil;
@@ -62,18 +63,18 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
      * <p>
      * Example:
      * <pre>{@code
-     * <requireNonObsoleteDependencyManagement>
+     * <banObsoleteDependencyOverrides>
      *   <ignorePatterns>
      *     <ignorePattern>junit:junit:jar</ignorePattern>
      *     <ignorePattern>org.mockito:mockito-core:jar</ignorePattern>
      *   </ignorePatterns>
-     * </requireNonObsoleteDependencyManagement>
+     * </banObsoleteDependencyOverrides>
      * }</pre>
      */
     private List<String> ignorePatterns;
 
     @Inject
-    public RequireNonObsoleteDependencyManagement(MavenProject project, BomResolverUtil bomResolverUtil) {
+    public BanObsoleteDependencyOverrides(MavenProject project, BomResolverUtil bomResolverUtil) {
         this.project = Objects.requireNonNull(project);
         this.bomResolverUtil = Objects.requireNonNull(bomResolverUtil);
     }
@@ -97,7 +98,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
     @Override
     public void execute() throws EnforcerRuleException {
         if (skip) {
-            getLog().info("requireNonObsoleteDependencyManagement skipped");
+            getLog().info("banObsoleteDependencyOverrides skipped");
             return;
         }
 
@@ -115,8 +116,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             }
 
             if (!importedBoms.isEmpty()) {
-                getLog().debug("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size()
-                        + " imported BOM(s)");
+                getLog().debug("[BanObsoleteDependencyOverrides] Found " + importedBoms.size() + " imported BOM(s)");
 
                 // Phase 2: Resolve BOM managed dependencies
                 Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
@@ -130,13 +130,13 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                                 bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
                         Map<String, BomResolverUtil.BomManagedDependency> resolved =
                                 bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
-                        getLog().debug("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + resolvedGroupId + ":"
+                        getLog().debug("[BanObsoleteDependencyOverrides] Resolved BOM: " + resolvedGroupId + ":"
                                 + resolvedArtifactId + ":" + resolvedVersion + " with " + resolved.size()
                                 + " managed dependencies");
                         // Later BOMs override earlier ones
                         bomDependencies.putAll(resolved);
                     } catch (Exception e) {
-                        getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to resolve BOM "
+                        getLog().warn("[BanObsoleteDependencyOverrides] Failed to resolve BOM "
                                 + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":" + bomDep.getVersion()
                                 + ": " + e.getMessage());
                     }
@@ -159,7 +159,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
 
                         // Skip if this dependency is in the ignore list
                         if (ignorePatterns != null && ignorePatterns.contains(key)) {
-                            getLog().debug("[RequireNonObsoleteDependencyManagement] Skipping " + key
+                            getLog().debug("[BanObsoleteDependencyOverrides] Skipping " + key
                                     + " (matches ignorePatterns)");
                             continue;
                         }
@@ -188,7 +188,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                                         bomDep.bomArtifactId()));
                             }
                         } catch (Exception e) {
-                            getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to compare versions for "
+                            getLog().warn("[BanObsoleteDependencyOverrides] Failed to compare versions for "
                                     + key
                                     + ": declared=" + dep.getVersion() + ", BOM=" + bomDep.version() + ": "
                                     + e.getMessage());
@@ -224,8 +224,8 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                 try {
                     resolvedDeclaredValue = bomResolverUtil.resolveProperties(getLog(), declaredValue, project);
                 } catch (IllegalStateException e) {
-                    getLog().debug("[RequireNonObsoleteDependencyManagement] Could not resolve properties in "
-                            + propName + "=" + declaredValue + ", skipping comparison: " + e.getMessage());
+                    getLog().debug("[BanObsoleteDependencyOverrides] Could not resolve properties in " + propName + "="
+                            + declaredValue + ", skipping comparison: " + e.getMessage());
                     continue;
                 }
 
@@ -239,7 +239,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                                 new ObsoletePropertyOverride(propName, resolvedDeclaredValue, parentValue));
                     }
                 } catch (Exception e) {
-                    getLog().debug("[RequireNonObsoleteDependencyManagement] Failed to compare property versions for "
+                    getLog().debug("[BanObsoleteDependencyOverrides] Failed to compare property versions for "
                             + propName + ": declared=" + resolvedDeclaredValue + ", parent=" + parentValue + ": "
                             + e.getMessage());
                 }
@@ -315,14 +315,14 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                     To fix this issue:
                       1. Remove the obsolete overrides from <dependencyManagement> and/or <properties>, OR
                       2. Update them to versions newer than what the BOM/parent provides, OR
-                      3. <requireNonObsoleteDependencyManagement.skip>true</requireNonObsoleteDependencyManagement.skip>
+                      3. <banObsoleteDependencyOverrides.skip>true</banObsoleteDependencyOverrides.skip>
 
                     See https://www.jenkins.io/doc/developer/plugin-development/dependency-management/ for more information.""");
 
             throw new EnforcerRuleException(message.toString());
         }
 
-        getLog().debug("[RequireNonObsoleteDependencyManagement] No obsolete overrides found");
+        getLog().debug("[BanObsoleteDependencyOverrides] No obsolete overrides found");
     }
 
     private record ObsoleteOverride(

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -111,9 +111,6 @@ class BomResolverUtil {
         resolved = resolved.replace("${project.version}", project.getVersion());
         resolved = resolved.replace("${project.groupId}", project.getGroupId());
         resolved = resolved.replace("${project.artifactId}", project.getArtifactId());
-        resolved = resolved.replace("${pom.version}", project.getVersion());
-        resolved = resolved.replace("${pom.groupId}", project.getGroupId());
-        resolved = resolved.replace("${pom.artifactId}", project.getArtifactId());
 
         // Resolve user-defined properties
         for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -123,7 +123,7 @@ class BomResolverUtil {
             throw new IllegalStateException("Unresolved properties in BOM dependency version: " + value);
         }
 
-        logger.info("Resolved properties: " + value + " → " + resolved);
+        logger.debug("Resolved properties: " + value + " → " + resolved);
 
         return resolved;
     }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -59,9 +59,10 @@ class BomResolverUtil {
         java.util.List<RemoteRepository> remoteRepositories = project.getRemoteProjectRepositories();
 
         // Resolve the BOM artifact (resolve properties in all coordinates)
+        String resolvedArtifactId = resolveProperties(logger, bomDep.getArtifactId(), project);
         Artifact bomArtifact = new DefaultArtifact(
                 resolveProperties(logger, bomDep.getGroupId(), project),
-                resolveProperties(logger, bomDep.getArtifactId(), project),
+                resolvedArtifactId,
                 bomDep.getClassifier(),
                 "pom",
                 resolveProperties(logger, bomDep.getVersion(), project));
@@ -86,13 +87,12 @@ class BomResolverUtil {
         Map<String, BomManagedDependency> bomDependencies = new LinkedHashMap<>();
         DependencyManagement bomDepMgmt = bomProject.getDependencyManagement();
         if (bomDepMgmt != null && bomDepMgmt.getDependencies() != null) {
-            String bomArtifactId = bomDep.getArtifactId();
             for (Dependency dep : bomDepMgmt.getDependencies()) {
                 if (dep.getVersion() != null && !dep.getVersion().isEmpty()) {
                     String key = dep.getManagementKey();
                     String version = resolveProperties(logger, dep.getVersion(), bomProject);
                     // Later BOMs override earlier ones (Maven behavior)
-                    bomDependencies.put(key, new BomManagedDependency(version, bomArtifactId));
+                    bomDependencies.put(key, new BomManagedDependency(version, resolvedArtifactId));
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -45,7 +45,7 @@ class BomResolverUtil {
      *
      * @param bomDep the BOM dependency to resolve
      * @param project the current project (for property resolution)
-     * @return map of "groupId:artifactId" to managed dependency info
+     * @return map of management key to managed dependency info
      * @throws ArtifactResolutionException if BOM cannot be resolved
      * @throws ProjectBuildingException if BOM POM cannot be built
      */
@@ -87,7 +87,7 @@ class BomResolverUtil {
             String bomArtifactId = bomDep.getArtifactId();
             for (Dependency dep : bomDepMgmt.getDependencies()) {
                 if (dep.getVersion() != null && !dep.getVersion().isEmpty()) {
-                    String key = dep.getGroupId() + ":" + dep.getArtifactId();
+                    String key = dep.getManagementKey();
                     String version = resolveProperties(dep.getVersion(), bomProject);
                     // Later BOMs override earlier ones (Maven behavior)
                     bomDependencies.put(key, new BomManagedDependency(version, bomArtifactId));

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -56,10 +56,10 @@ class BomResolverUtil {
         RepositorySystemSession repositorySession = session.getRepositorySession();
         java.util.List<RemoteRepository> remoteRepositories = project.getRemoteProjectRepositories();
 
-        // Resolve the BOM artifact
+        // Resolve the BOM artifact (resolve properties in all coordinates)
         Artifact bomArtifact = new DefaultArtifact(
-                bomDep.getGroupId(),
-                bomDep.getArtifactId(),
+                resolveProperties(bomDep.getGroupId(), project),
+                resolveProperties(bomDep.getArtifactId(), project),
                 bomDep.getClassifier(),
                 "pom",
                 resolveProperties(bomDep.getVersion(), project));

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -49,7 +50,8 @@ class BomResolverUtil {
      * @throws ArtifactResolutionException if BOM cannot be resolved
      * @throws ProjectBuildingException if BOM POM cannot be built
      */
-    Map<String, BomManagedDependency> resolveBomManagedDependencies(Dependency bomDep, MavenProject project)
+    Map<String, BomManagedDependency> resolveBomManagedDependencies(
+            EnforcerLogger logger, Dependency bomDep, MavenProject project)
             throws ArtifactResolutionException, ProjectBuildingException {
 
         // Get repository session and repositories from the Maven session
@@ -58,11 +60,11 @@ class BomResolverUtil {
 
         // Resolve the BOM artifact (resolve properties in all coordinates)
         Artifact bomArtifact = new DefaultArtifact(
-                resolveProperties(bomDep.getGroupId(), project),
-                resolveProperties(bomDep.getArtifactId(), project),
+                resolveProperties(logger, bomDep.getGroupId(), project),
+                resolveProperties(logger, bomDep.getArtifactId(), project),
                 bomDep.getClassifier(),
                 "pom",
-                resolveProperties(bomDep.getVersion(), project));
+                resolveProperties(logger, bomDep.getVersion(), project));
 
         ArtifactRequest request = new ArtifactRequest();
         request.setArtifact(bomArtifact);
@@ -88,7 +90,7 @@ class BomResolverUtil {
             for (Dependency dep : bomDepMgmt.getDependencies()) {
                 if (dep.getVersion() != null && !dep.getVersion().isEmpty()) {
                     String key = dep.getManagementKey();
-                    String version = resolveProperties(dep.getVersion(), bomProject);
+                    String version = resolveProperties(logger, dep.getVersion(), bomProject);
                     // Later BOMs override earlier ones (Maven behavior)
                     bomDependencies.put(key, new BomManagedDependency(version, bomArtifactId));
                 }
@@ -98,17 +100,25 @@ class BomResolverUtil {
         return bomDependencies;
     }
 
-    String resolveProperties(String value, MavenProject project) {
+    String resolveProperties(EnforcerLogger logger, String value, MavenProject project) {
         if (value == null || !value.contains("${")) {
             return value;
         }
 
         String resolved = value;
+        // TODO this fails to resolve ${project.version}
         for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
             String key = String.valueOf(entry.getKey());
             String val = String.valueOf(entry.getValue());
             resolved = resolved.replace("${" + key + "}", val);
         }
+
+        if (resolved.contains("${")) {
+            throw new IllegalStateException("Unresolved properties in BOM dependency version: " + value);
+        }
+
+        logger.info("Resolved properties: " + value + " → " + resolved);
+
         return resolved;
     }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -98,7 +98,7 @@ class BomResolverUtil {
         return bomDependencies;
     }
 
-    private String resolveProperties(String value, MavenProject project) {
+    String resolveProperties(String value, MavenProject project) {
         if (value == null || !value.contains("${")) {
             return value;
         }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -106,7 +106,16 @@ class BomResolverUtil {
         }
 
         String resolved = value;
-        // TODO this fails to resolve ${project.version}
+
+        // Resolve standard Maven project properties first
+        resolved = resolved.replace("${project.version}", project.getVersion());
+        resolved = resolved.replace("${project.groupId}", project.getGroupId());
+        resolved = resolved.replace("${project.artifactId}", project.getArtifactId());
+        resolved = resolved.replace("${pom.version}", project.getVersion());
+        resolved = resolved.replace("${pom.groupId}", project.getGroupId());
+        resolved = resolved.replace("${pom.artifactId}", project.getArtifactId());
+
+        // Resolve user-defined properties
         for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
             String key = String.valueOf(entry.getKey());
             String val = String.valueOf(entry.getValue());

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/BomResolverUtil.java
@@ -1,0 +1,116 @@
+package org.jenkinsci.maven.plugins.hpi.enforcer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+/**
+ * Utility for resolving BOMs and their managed dependencies.
+ */
+@Named
+class BomResolverUtil {
+
+    private final RepositorySystem repositorySystem;
+    private final MavenSession session;
+    private final ProjectBuilder projectBuilder;
+
+    @Inject
+    BomResolverUtil(RepositorySystem repositorySystem, MavenSession session, ProjectBuilder projectBuilder) {
+        this.repositorySystem = Objects.requireNonNull(repositorySystem);
+        this.session = Objects.requireNonNull(session);
+        this.projectBuilder = Objects.requireNonNull(projectBuilder);
+    }
+
+    /**
+     * Resolves a BOM and extracts its managed dependencies.
+     *
+     * @param bomDep the BOM dependency to resolve
+     * @param project the current project (for property resolution)
+     * @return map of "groupId:artifactId" to managed dependency info
+     * @throws ArtifactResolutionException if BOM cannot be resolved
+     * @throws ProjectBuildingException if BOM POM cannot be built
+     */
+    Map<String, BomManagedDependency> resolveBomManagedDependencies(Dependency bomDep, MavenProject project)
+            throws ArtifactResolutionException, ProjectBuildingException {
+
+        // Get repository session and repositories from the Maven session
+        RepositorySystemSession repositorySession = session.getRepositorySession();
+        java.util.List<RemoteRepository> remoteRepositories = project.getRemoteProjectRepositories();
+
+        // Resolve the BOM artifact
+        Artifact bomArtifact = new DefaultArtifact(
+                bomDep.getGroupId(),
+                bomDep.getArtifactId(),
+                bomDep.getClassifier(),
+                "pom",
+                resolveProperties(bomDep.getVersion(), project));
+
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(bomArtifact);
+        request.setRepositories(remoteRepositories);
+
+        ArtifactResult result = repositorySystem.resolveArtifact(repositorySession, request);
+        Artifact resolvedBom = result.getArtifact();
+
+        // Build MavenProject from the BOM
+        ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        buildingRequest.setResolveDependencies(false);
+        buildingRequest.setProcessPlugins(false);
+        buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+
+        MavenProject bomProject =
+                projectBuilder.build(resolvedBom.getFile(), buildingRequest).getProject();
+
+        // Extract managed dependencies from the BOM
+        Map<String, BomManagedDependency> bomDependencies = new LinkedHashMap<>();
+        DependencyManagement bomDepMgmt = bomProject.getDependencyManagement();
+        if (bomDepMgmt != null && bomDepMgmt.getDependencies() != null) {
+            String bomArtifactId = bomDep.getArtifactId();
+            for (Dependency dep : bomDepMgmt.getDependencies()) {
+                if (dep.getVersion() != null && !dep.getVersion().isEmpty()) {
+                    String key = dep.getGroupId() + ":" + dep.getArtifactId();
+                    String version = resolveProperties(dep.getVersion(), bomProject);
+                    // Later BOMs override earlier ones (Maven behavior)
+                    bomDependencies.put(key, new BomManagedDependency(version, bomArtifactId));
+                }
+            }
+        }
+
+        return bomDependencies;
+    }
+
+    private String resolveProperties(String value, MavenProject project) {
+        if (value == null || !value.contains("${")) {
+            return value;
+        }
+
+        String resolved = value;
+        for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            String val = String.valueOf(entry.getValue());
+            resolved = resolved.replace("${" + key + "}", val);
+        }
+        return resolved;
+    }
+
+    record BomManagedDependency(String version, String bomArtifactId) {}
+}

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -99,14 +99,15 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
     @Override
     public void execute() throws EnforcerRuleException {
         if (skip) {
-            getLog().info("Skipping RequireNonObsoleteDependencyManagement rule");
+            getLog().info("[RequireNonObsoleteDependencyManagement] Skipping rule");
             return;
         }
 
         // Use the original model to see the raw dependencyManagement before BOM imports are resolved
         DependencyManagement depMgmt = project.getOriginalModel().getDependencyManagement();
         if (depMgmt == null || depMgmt.getDependencies() == null) {
-            getLog().info("No dependencyManagement section found, skipping rule");
+            getLog().info(
+                            "[RequireNonObsoleteDependencyManagement] No dependencyManagement section found, skipping rule");
             return;
         }
 
@@ -119,11 +120,11 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
         }
 
         if (importedBoms.isEmpty()) {
-            getLog().info("No imported BOMs found, skipping rule");
+            getLog().info("[RequireNonObsoleteDependencyManagement] No imported BOMs found, skipping rule");
             return;
         }
 
-        getLog().info("Found " + importedBoms.size() + " imported BOM(s)");
+        getLog().info("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size() + " imported BOM(s)");
 
         // Phase 2: Resolve BOM managed dependencies
         Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
@@ -131,18 +132,20 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             try {
                 Map<String, BomResolverUtil.BomManagedDependency> resolved =
                         bomResolverUtil.resolveBomManagedDependencies(bomDep, project);
-                getLog().info("Resolved BOM: " + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":"
-                        + bomDep.getVersion() + " with " + resolved.size() + " managed dependencies");
+                getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId() + ":"
+                        + bomDep.getArtifactId() + ":" + bomDep.getVersion() + " with " + resolved.size()
+                        + " managed dependencies");
                 // Later BOMs override earlier ones
                 bomDependencies.putAll(resolved);
             } catch (Exception e) {
-                getLog().warn("Failed to resolve BOM " + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":"
-                        + bomDep.getVersion() + ": " + e.getMessage());
+                getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to resolve BOM " + bomDep.getGroupId()
+                        + ":" + bomDep.getArtifactId() + ":" + bomDep.getVersion() + ": " + e.getMessage());
             }
         }
 
         if (bomDependencies.isEmpty()) {
-            getLog().info("No managed dependencies found in BOMs, skipping rule");
+            getLog().info(
+                            "[RequireNonObsoleteDependencyManagement] No managed dependencies found in BOMs, skipping rule");
             return;
         }
 
@@ -163,7 +166,8 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
 
             // Skip if this dependency is in the ignore list
             if (ignorePatterns != null && ignorePatterns.contains(key)) {
-                getLog().debug("Skipping " + key + " (matches ignorePatterns)");
+                getLog().debug("[RequireNonObsoleteDependencyManagement] Skipping " + key
+                        + " (matches ignorePatterns)");
                 continue;
             }
 
@@ -190,8 +194,8 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                             bomDep.bomArtifactId()));
                 }
             } catch (Exception e) {
-                getLog().warn("Failed to compare versions for " + key + ": declared=" + declaredVersion + ", BOM="
-                        + bomVersion + ": " + e.getMessage());
+                getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to compare versions for " + key
+                        + ": declared=" + declaredVersion + ", BOM=" + bomVersion + ": " + e.getMessage());
             }
         }
 
@@ -231,7 +235,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             throw new EnforcerRuleException(message.toString());
         }
 
-        getLog().info("No obsolete overrides found");
+        getLog().info("[RequireNonObsoleteDependencyManagement] No obsolete overrides found");
     }
 
     private String resolveProperties(String value) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.artifact.versioning.ComparableVersion;
@@ -100,140 +101,205 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             return;
         }
 
-        // Use the original model to see the raw dependencyManagement before BOM imports are resolved
-        DependencyManagement depMgmt = project.getOriginalModel().getDependencyManagement();
-        if (depMgmt == null || depMgmt.getDependencies() == null) {
-            getLog().info(
-                            "[RequireNonObsoleteDependencyManagement] No dependencyManagement section found, skipping rule");
-            return;
-        }
-
-        // Phase 1: Identify imported BOMs
-        List<Dependency> importedBoms = new ArrayList<>();
-        for (Dependency dep : depMgmt.getDependencies()) {
-            if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
-                importedBoms.add(dep);
-            }
-        }
-
-        if (importedBoms.isEmpty()) {
-            getLog().info("[RequireNonObsoleteDependencyManagement] No imported BOMs found, skipping rule");
-            return;
-        }
-
-        getLog().info("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size() + " imported BOM(s)");
-
-        // Phase 2: Resolve BOM managed dependencies
-        Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
-        for (Dependency bomDep : importedBoms) {
-            try {
-                String resolvedVersion = bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
-                Map<String, BomResolverUtil.BomManagedDependency> resolved =
-                        bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
-                getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId() + ":"
-                        + bomDep.getArtifactId() + ":" + resolvedVersion + " with " + resolved.size()
-                        + " managed dependencies");
-                // Later BOMs override earlier ones
-                bomDependencies.putAll(resolved);
-            } catch (Exception e) {
-                getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to resolve BOM " + bomDep.getGroupId()
-                        + ":" + bomDep.getArtifactId() + ":" + bomDep.getVersion() + ": " + e.getMessage());
-            }
-        }
-
-        if (bomDependencies.isEmpty()) {
-            getLog().info(
-                            "[RequireNonObsoleteDependencyManagement] No managed dependencies found in BOMs, skipping rule");
-            return;
-        }
-
-        // Phase 3: Check project's direct dependencyManagement entries
+        // Phase 1: Check dependencyManagement section
         List<ObsoleteOverride> violations = new ArrayList<>();
-        for (Dependency dep : depMgmt.getDependencies()) {
-            // Skip BOM imports themselves
-            if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
-                continue;
-            }
+        DependencyManagement depMgmt = project.getOriginalModel().getDependencyManagement();
 
-            // Skip if no version specified (relying on BOM)
-            if (dep.getVersion() == null || dep.getVersion().isEmpty()) {
-                continue;
-            }
-
-            String key = dep.getManagementKey();
-
-            // Skip if this dependency is in the ignore list
-            if (ignorePatterns != null && ignorePatterns.contains(key)) {
-                getLog().debug("[RequireNonObsoleteDependencyManagement] Skipping " + key
-                        + " (matches ignorePatterns)");
-                continue;
-            }
-
-            BomResolverUtil.BomManagedDependency bomDep = bomDependencies.get(key);
-            if (bomDep == null) {
-                continue;
-            }
-
-            try {
-                // Resolve property placeholders
-                String declaredVersion = bomResolverUtil.resolveProperties(getLog(), dep.getVersion(), project);
-                String bomVersion = bomDep.version();
-
-                // Compare versions
-                ComparableVersion declared = new ComparableVersion(declaredVersion);
-                ComparableVersion bom = new ComparableVersion(bomVersion);
-
-                if (declared.compareTo(bom) <= 0) {
-                    violations.add(new ObsoleteOverride(
-                            dep.getGroupId(),
-                            dep.getArtifactId(),
-                            declaredVersion,
-                            bomVersion,
-                            bomDep.bomArtifactId()));
+        if (depMgmt != null && depMgmt.getDependencies() != null) {
+            // Phase 1a: Identify imported BOMs
+            List<Dependency> importedBoms = new ArrayList<>();
+            for (Dependency dep : depMgmt.getDependencies()) {
+                if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                    importedBoms.add(dep);
                 }
-            } catch (Exception e) {
-                getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to compare versions for " + key
-                        + ": declared=" + dep.getVersion() + ", BOM=" + bomDep.version() + ": " + e.getMessage());
+            }
+
+            if (!importedBoms.isEmpty()) {
+                getLog().info("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size()
+                        + " imported BOM(s)");
+
+                // Phase 2: Resolve BOM managed dependencies
+                Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
+                for (Dependency bomDep : importedBoms) {
+                    try {
+                        String resolvedVersion =
+                                bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
+                        Map<String, BomResolverUtil.BomManagedDependency> resolved =
+                                bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
+                        getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId()
+                                + ":" + bomDep.getArtifactId() + ":" + resolvedVersion + " with " + resolved.size()
+                                + " managed dependencies");
+                        // Later BOMs override earlier ones
+                        bomDependencies.putAll(resolved);
+                    } catch (Exception e) {
+                        getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to resolve BOM "
+                                + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":" + bomDep.getVersion()
+                                + ": " + e.getMessage());
+                    }
+                }
+
+                if (!bomDependencies.isEmpty()) {
+                    // Phase 3: Check project's direct dependencyManagement entries
+                    for (Dependency dep : depMgmt.getDependencies()) {
+                        // Skip BOM imports themselves
+                        if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                            continue;
+                        }
+
+                        // Skip if no version specified (relying on BOM)
+                        if (dep.getVersion() == null || dep.getVersion().isEmpty()) {
+                            continue;
+                        }
+
+                        String key = dep.getManagementKey();
+
+                        // Skip if this dependency is in the ignore list
+                        if (ignorePatterns != null && ignorePatterns.contains(key)) {
+                            getLog().debug("[RequireNonObsoleteDependencyManagement] Skipping " + key
+                                    + " (matches ignorePatterns)");
+                            continue;
+                        }
+
+                        BomResolverUtil.BomManagedDependency bomDep = bomDependencies.get(key);
+                        if (bomDep == null) {
+                            continue;
+                        }
+
+                        try {
+                            // Resolve property placeholders
+                            String declaredVersion =
+                                    bomResolverUtil.resolveProperties(getLog(), dep.getVersion(), project);
+                            String bomVersion = bomDep.version();
+
+                            // Compare versions
+                            ComparableVersion declared = new ComparableVersion(declaredVersion);
+                            ComparableVersion bom = new ComparableVersion(bomVersion);
+
+                            if (declared.compareTo(bom) <= 0) {
+                                violations.add(new ObsoleteOverride(
+                                        dep.getGroupId(),
+                                        dep.getArtifactId(),
+                                        declaredVersion,
+                                        bomVersion,
+                                        bomDep.bomArtifactId()));
+                            }
+                        } catch (Exception e) {
+                            getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to compare versions for "
+                                    + key
+                                    + ": declared=" + dep.getVersion() + ", BOM=" + bomDep.version() + ": "
+                                    + e.getMessage());
+                        }
+                    }
+                }
             }
         }
 
-        // Phase 4: Report all violations
-        if (!violations.isEmpty()) {
-            StringBuilder message = new StringBuilder();
-            message.append("""
-                    Found obsolete dependency version overrides in <dependencyManagement>.
+        // Phase 4: Check for obsolete property overrides (e.g., jenkins.version)
+        List<ObsoletePropertyOverride> propertyViolations = new ArrayList<>();
+        MavenProject parentProject = project.getParent();
+        if (parentProject != null) {
+            Properties declaredProps = project.getOriginalModel().getProperties();
+            Properties parentProps = parentProject.getProperties();
 
-                    The following dependencies declare versions that are older than or equal to versions
-                    provided by imported BOMs. These overrides are unnecessary and should be removed:
-
-                    """);
-
-            for (ObsoleteOverride violation : violations) {
-                message.append("  - ")
-                        .append(violation.groupId)
-                        .append(":")
-                        .append(violation.artifactId)
-                        .append(": declared ")
-                        .append(violation.declaredVersion);
-
-                if (violation.declaredVersion.equals(violation.bomVersion)) {
-                    message.append(" == ");
-                } else {
-                    message.append(" < ");
+            for (String propName : declaredProps.stringPropertyNames()) {
+                // Only check *.version properties
+                if (!propName.endsWith(".version")) {
+                    continue;
                 }
 
-                message.append(violation.bomVersion)
-                        .append(" from imported BOM ")
-                        .append(violation.bomArtifactId)
-                        .append(" (or a BOM it imports)")
-                        .append("\n");
+                String declaredValue = declaredProps.getProperty(propName);
+                String parentValue = parentProps.getProperty(propName);
+
+                // Skip if parent doesn't define this property
+                if (parentValue == null) {
+                    continue;
+                }
+
+                // Compare versions (flag if declared <= parent)
+                try {
+                    ComparableVersion declared = new ComparableVersion(declaredValue);
+                    ComparableVersion parent = new ComparableVersion(parentValue);
+
+                    if (declared.compareTo(parent) <= 0) {
+                        propertyViolations.add(new ObsoletePropertyOverride(propName, declaredValue, parentValue));
+                    }
+                } catch (Exception e) {
+                    getLog().debug("[RequireNonObsoleteDependencyManagement] Failed to compare property versions for "
+                            + propName + ": declared=" + declaredValue + ", parent=" + parentValue + ": "
+                            + e.getMessage());
+                }
+            }
+        }
+
+        // Phase 5: Report all violations together
+        if (!violations.isEmpty() || !propertyViolations.isEmpty()) {
+            StringBuilder message = new StringBuilder();
+
+            if (!violations.isEmpty()) {
+                message.append("""
+                        Found obsolete dependency version overrides in <dependencyManagement>.
+
+                        The following dependencies declare versions that are older than or equal to versions
+                        provided by imported BOMs. These overrides are unnecessary and should be removed:
+
+                        """);
+
+                for (ObsoleteOverride violation : violations) {
+                    message.append("  - ")
+                            .append(violation.groupId)
+                            .append(":")
+                            .append(violation.artifactId)
+                            .append(": declared ")
+                            .append(violation.declaredVersion);
+
+                    if (violation.declaredVersion.equals(violation.bomVersion)) {
+                        message.append(" == ");
+                    } else {
+                        message.append(" < ");
+                    }
+
+                    message.append(violation.bomVersion)
+                            .append(" from imported BOM ")
+                            .append(violation.bomArtifactId)
+                            .append(" (or a BOM it imports)")
+                            .append("\n");
+                }
+            }
+
+            if (!propertyViolations.isEmpty()) {
+                if (!violations.isEmpty()) {
+                    message.append("\n");
+                }
+
+                message.append("""
+                        Found obsolete property overrides.
+
+                        The following *.version properties are set to older or equal versions compared to the parent POM.
+                        These overrides may be unnecessary and should be reviewed:
+
+                        """);
+
+                for (ObsoletePropertyOverride violation : propertyViolations) {
+                    message.append("  - ")
+                            .append(violation.propertyName)
+                            .append(": declared ")
+                            .append(violation.declaredValue);
+
+                    if (violation.declaredValue.equals(violation.parentValue)) {
+                        message.append(" == ");
+                    } else {
+                        message.append(" < ");
+                    }
+
+                    message.append(violation.parentValue).append(" from parent POM\n");
+                }
             }
 
             message.append("""
 
                     To fix this issue:
-                      1. Remove the version specifications from <dependencyManagement> for these dependencies, OR
-                      2. Update them to versions newer than what the BOM provides, OR
+                      1. Remove the obsolete overrides from <dependencyManagement> and/or <properties>, OR
+                      2. Update them to versions newer than what the BOM/parent provides, OR
                       3. <requireNonObsoleteDependencyManagement.skip>true</requireNonObsoleteDependencyManagement.skip>
 
                     See https://www.jenkins.io/doc/developer/plugin-development/dependency-management/ for more information.""");
@@ -246,4 +312,6 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
 
     private record ObsoleteOverride(
             String groupId, String artifactId, String declaredVersion, String bomVersion, String bomArtifactId) {}
+
+    private record ObsoletePropertyOverride(String propertyName, String declaredValue, String parentValue) {}
 }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -213,11 +213,18 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                         .append(":")
                         .append(violation.artifactId)
                         .append(": declared ")
-                        .append(violation.declaredVersion)
-                        .append(" but imported BOM ")
+                        .append(violation.declaredVersion);
+
+                if (violation.declaredVersion.equals(violation.bomVersion)) {
+                    message.append(" == ");
+                } else {
+                    message.append(" < ");
+                }
+
+                message.append(violation.bomVersion)
+                        .append(" from imported BOM ")
                         .append(violation.bomArtifactId)
-                        .append(" (or a BOM it imports) provides ")
-                        .append(violation.bomVersion)
+                        .append(" (or a BOM it imports)")
                         .append("\n");
             }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -128,7 +128,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
         for (Dependency bomDep : importedBoms) {
             try {
                 Map<String, BomResolverUtil.BomManagedDependency> resolved =
-                        bomResolverUtil.resolveBomManagedDependencies(bomDep, project);
+                        bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
                 getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId() + ":"
                         + bomDep.getArtifactId() + ":" + bomDep.getVersion() + " with " + resolved.size()
                         + " managed dependencies");

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -57,14 +57,14 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
 
     /**
      * List of dependencies to ignore when checking for obsolete overrides.
-     * Each entry should be in the format "groupId:artifactId".
+     * Each entry should be a management key (groupId:artifactId:type[:classifier]).
      * <p>
      * Example:
      * <pre>{@code
      * <requireNonObsoleteDependencyManagement>
      *   <ignorePatterns>
-     *     <ignorePattern>junit:junit</ignorePattern>
-     *     <ignorePattern>org.mockito:mockito-core</ignorePattern>
+     *     <ignorePattern>junit:junit:jar</ignorePattern>
+     *     <ignorePattern>org.mockito:mockito-core:jar</ignorePattern>
      *   </ignorePatterns>
      * </requireNonObsoleteDependencyManagement>
      * }</pre>
@@ -159,7 +159,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                 continue;
             }
 
-            String key = dep.getGroupId() + ":" + dep.getArtifactId();
+            String key = dep.getManagementKey();
 
             // Skip if this dependency is in the ignore list
             if (ignorePatterns != null && ignorePatterns.contains(key)) {

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -173,12 +173,12 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                 continue;
             }
 
-            // Resolve property placeholders
-            String declaredVersion = bomResolverUtil.resolveProperties(dep.getVersion(), project);
-            String bomVersion = bomDep.version();
-
-            // Compare versions
             try {
+                // Resolve property placeholders
+                String declaredVersion = bomResolverUtil.resolveProperties(getLog(), dep.getVersion(), project);
+                String bomVersion = bomDep.version();
+
+                // Compare versions
                 ComparableVersion declared = new ComparableVersion(declaredVersion);
                 ComparableVersion bom = new ComparableVersion(bomVersion);
 
@@ -192,7 +192,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                 }
             } catch (Exception e) {
                 getLog().warn("[RequireNonObsoleteDependencyManagement] Failed to compare versions for " + key
-                        + ": declared=" + declaredVersion + ", BOM=" + bomVersion + ": " + e.getMessage());
+                        + ": declared=" + dep.getVersion() + ", BOM=" + bomDep.version() + ": " + e.getMessage());
             }
         }
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -1,0 +1,213 @@
+package org.jenkinsci.maven.plugins.hpi.enforcer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Maven Enforcer rule that detects obsolete dependency version overrides in {@code <dependencyManagement>}.
+ * <p>
+ * This rule fails the build when {@code <dependencyManagement>} specifies versions for dependencies that are
+ * older than or equal to versions provided by imported BOMs. This helps identify unnecessary overrides that
+ * can be removed when updating BOM versions.
+ * </p>
+ * <p>
+ * Example usage in a POM:
+ * </p>
+ * <pre>{@code
+ * <build>
+ *   <plugins>
+ *     <plugin>
+ *       <artifactId>maven-enforcer-plugin</artifactId>
+ *       <executions>
+ *         <execution>
+ *           <goals><goal>enforce</goal></goals>
+ *           <configuration>
+ *             <rules>
+ *               <requireNonObsoleteDependencyManagement/>
+ *             </rules>
+ *           </configuration>
+ *         </execution>
+ *       </executions>
+ *     </plugin>
+ *   </plugins>
+ * </build>
+ * }</pre>
+ */
+@Named("requireNonObsoleteDependencyManagement")
+public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule {
+
+    /**
+     * Whether to skip this rule.
+     */
+    @Parameter(property = "requireNonObsoleteDependencyManagement.skip", defaultValue = "false")
+    private boolean skip;
+
+    private final MavenProject project;
+    private final BomResolverUtil bomResolverUtil;
+
+    @Inject
+    public RequireNonObsoleteDependencyManagement(MavenProject project, BomResolverUtil bomResolverUtil) {
+        this.project = Objects.requireNonNull(project);
+        this.bomResolverUtil = Objects.requireNonNull(bomResolverUtil);
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        if (skip) {
+            getLog().info("Skipping RequireNonObsoleteDependencyManagement rule");
+            return;
+        }
+
+        // Use the original model to see the raw dependencyManagement before BOM imports are resolved
+        DependencyManagement depMgmt = project.getOriginalModel().getDependencyManagement();
+        if (depMgmt == null || depMgmt.getDependencies() == null) {
+            getLog().info("No dependencyManagement section found, skipping rule");
+            return;
+        }
+
+        // Phase 1: Identify imported BOMs
+        List<Dependency> importedBoms = new ArrayList<>();
+        for (Dependency dep : depMgmt.getDependencies()) {
+            if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                importedBoms.add(dep);
+            }
+        }
+
+        if (importedBoms.isEmpty()) {
+            getLog().info("No imported BOMs found, skipping rule");
+            return;
+        }
+
+        getLog().info("Found " + importedBoms.size() + " imported BOM(s)");
+
+        // Phase 2: Resolve BOM managed dependencies
+        Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
+        for (Dependency bomDep : importedBoms) {
+            try {
+                Map<String, BomResolverUtil.BomManagedDependency> resolved =
+                        bomResolverUtil.resolveBomManagedDependencies(bomDep, project);
+                getLog().info("Resolved BOM: " + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":"
+                        + bomDep.getVersion() + " with " + resolved.size() + " managed dependencies");
+                // Later BOMs override earlier ones
+                bomDependencies.putAll(resolved);
+            } catch (Exception e) {
+                getLog().warn("Failed to resolve BOM " + bomDep.getGroupId() + ":" + bomDep.getArtifactId() + ":"
+                        + bomDep.getVersion() + ": " + e.getMessage());
+            }
+        }
+
+        if (bomDependencies.isEmpty()) {
+            getLog().info("No managed dependencies found in BOMs, skipping rule");
+            return;
+        }
+
+        // Phase 3: Check project's direct dependencyManagement entries
+        List<ObsoleteOverride> violations = new ArrayList<>();
+        for (Dependency dep : depMgmt.getDependencies()) {
+            // Skip BOM imports themselves
+            if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                continue;
+            }
+
+            // Skip if no version specified (relying on BOM)
+            if (dep.getVersion() == null || dep.getVersion().isEmpty()) {
+                continue;
+            }
+
+            String key = dep.getGroupId() + ":" + dep.getArtifactId();
+            BomResolverUtil.BomManagedDependency bomDep = bomDependencies.get(key);
+            if (bomDep == null) {
+                continue;
+            }
+
+            // Resolve property placeholders
+            String declaredVersion = resolveProperties(dep.getVersion());
+            String bomVersion = bomDep.version();
+
+            // Compare versions
+            try {
+                ComparableVersion declared = new ComparableVersion(declaredVersion);
+                ComparableVersion bom = new ComparableVersion(bomVersion);
+
+                if (declared.compareTo(bom) <= 0) {
+                    violations.add(new ObsoleteOverride(
+                            dep.getGroupId(),
+                            dep.getArtifactId(),
+                            declaredVersion,
+                            bomVersion,
+                            bomDep.bomArtifactId()));
+                }
+            } catch (Exception e) {
+                getLog().warn("Failed to compare versions for " + key + ": declared=" + declaredVersion + ", BOM="
+                        + bomVersion + ": " + e.getMessage());
+            }
+        }
+
+        // Phase 4: Report all violations
+        if (!violations.isEmpty()) {
+            StringBuilder message = new StringBuilder();
+            message.append("""
+                    Found obsolete dependency version overrides in <dependencyManagement>.
+
+                    The following dependencies declare versions that are older than or equal to versions
+                    provided by imported BOMs. These overrides are unnecessary and should be removed:
+
+                    """);
+
+            for (ObsoleteOverride violation : violations) {
+                message.append("  - ")
+                        .append(violation.groupId)
+                        .append(":")
+                        .append(violation.artifactId)
+                        .append(": declared ")
+                        .append(violation.declaredVersion)
+                        .append(" but ")
+                        .append(violation.bomArtifactId)
+                        .append(" provides ")
+                        .append(violation.bomVersion)
+                        .append("\n");
+            }
+
+            message.append("""
+
+                    To fix this issue:
+                      1. Remove the version specifications from <dependencyManagement> for these dependencies, OR
+                      2. Update them to versions newer than what the BOM provides
+
+                    See https://www.jenkins.io/doc/developer/plugin-development/dependency-management/ for more information.""");
+
+            throw new EnforcerRuleException(message.toString());
+        }
+
+        getLog().info("No obsolete overrides found");
+    }
+
+    private String resolveProperties(String value) {
+        if (value == null || !value.contains("${")) {
+            return value;
+        }
+
+        String resolved = value;
+        for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            String val = String.valueOf(entry.getValue());
+            resolved = resolved.replace("${" + key + "}", val);
+        }
+        return resolved;
+    }
+
+    private record ObsoleteOverride(
+            String groupId, String artifactId, String declaredVersion, String bomVersion, String bomArtifactId) {}
+}

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -225,7 +225,8 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
 
                     To fix this issue:
                       1. Remove the version specifications from <dependencyManagement> for these dependencies, OR
-                      2. Update them to versions newer than what the BOM provides
+                      2. Update them to versions newer than what the BOM provides, OR
+                      3. <requireNonObsoleteDependencyManagement.skip>true</requireNonObsoleteDependencyManagement.skip>
 
                     See https://www.jenkins.io/doc/developer/plugin-development/dependency-management/ for more information.""");
 

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -48,19 +48,52 @@ import org.apache.maven.project.MavenProject;
 @Named("requireNonObsoleteDependencyManagement")
 public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule {
 
+    private final MavenProject project;
+    private final BomResolverUtil bomResolverUtil;
+
     /**
      * Whether to skip this rule.
      */
     @Parameter(property = "requireNonObsoleteDependencyManagement.skip", defaultValue = "false")
-    private boolean skip;
+    private boolean skip = false;
 
-    private final MavenProject project;
-    private final BomResolverUtil bomResolverUtil;
+    /**
+     * List of dependencies to ignore when checking for obsolete overrides.
+     * Each entry should be in the format "groupId:artifactId".
+     * <p>
+     * Example:
+     * <pre>{@code
+     * <requireNonObsoleteDependencyManagement>
+     *   <ignorePatterns>
+     *     <ignorePattern>junit:junit</ignorePattern>
+     *     <ignorePattern>org.mockito:mockito-core</ignorePattern>
+     *   </ignorePatterns>
+     * </requireNonObsoleteDependencyManagement>
+     * }</pre>
+     */
+    @Parameter
+    private List<String> ignorePatterns;
 
     @Inject
     public RequireNonObsoleteDependencyManagement(MavenProject project, BomResolverUtil bomResolverUtil) {
         this.project = Objects.requireNonNull(project);
         this.bomResolverUtil = Objects.requireNonNull(bomResolverUtil);
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
+    }
+
+    public boolean isSkip() {
+        return skip;
+    }
+
+    public void setIgnorePatterns(List<String> ignorePatterns) {
+        this.ignorePatterns = ignorePatterns;
+    }
+
+    public List<String> getIgnorePatterns() {
+        return ignorePatterns;
     }
 
     @Override
@@ -127,6 +160,13 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             }
 
             String key = dep.getGroupId() + ":" + dep.getArtifactId();
+
+            // Skip if this dependency is in the ignore list
+            if (ignorePatterns != null && ignorePatterns.contains(key)) {
+                getLog().debug("Skipping " + key + " (matches ignorePatterns)");
+                continue;
+            }
+
             BomResolverUtil.BomManagedDependency bomDep = bomDependencies.get(key);
             if (bomDep == null) {
                 continue;
@@ -173,9 +213,9 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                         .append(violation.artifactId)
                         .append(": declared ")
                         .append(violation.declaredVersion)
-                        .append(" but ")
+                        .append(" but imported BOM ")
                         .append(violation.bomArtifactId)
-                        .append(" provides ")
+                        .append(" (or a BOM it imports) provides ")
                         .append(violation.bomVersion)
                         .append("\n");
             }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -174,7 +174,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             }
 
             // Resolve property placeholders
-            String declaredVersion = resolveProperties(dep.getVersion());
+            String declaredVersion = bomResolverUtil.resolveProperties(dep.getVersion(), project);
             String bomVersion = bomDep.version();
 
             // Compare versions
@@ -234,20 +234,6 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
         }
 
         getLog().info("[RequireNonObsoleteDependencyManagement] No obsolete overrides found");
-    }
-
-    private String resolveProperties(String value) {
-        if (value == null || !value.contains("${")) {
-            return value;
-        }
-
-        String resolved = value;
-        for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
-            String key = String.valueOf(entry.getKey());
-            String val = String.valueOf(entry.getValue());
-            resolved = resolved.replace("${" + key + "}", val);
-        }
-        return resolved;
     }
 
     private record ObsoleteOverride(

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -12,7 +12,6 @@ import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -54,7 +53,6 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
     /**
      * Whether to skip this rule.
      */
-    @Parameter(property = "requireNonObsoleteDependencyManagement.skip", defaultValue = "false")
     private boolean skip = false;
 
     /**
@@ -71,7 +69,6 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
      * </requireNonObsoleteDependencyManagement>
      * }</pre>
      */
-    @Parameter
     private List<String> ignorePatterns;
 
     @Inject

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -215,17 +215,28 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                     continue;
                 }
 
+                // Resolve properties in declared value (e.g., ${jenkins.baseline}.3)
+                String resolvedDeclaredValue;
+                try {
+                    resolvedDeclaredValue = bomResolverUtil.resolveProperties(getLog(), declaredValue, project);
+                } catch (IllegalStateException e) {
+                    getLog().debug("[RequireNonObsoleteDependencyManagement] Could not resolve properties in "
+                            + propName + "=" + declaredValue + ", skipping comparison: " + e.getMessage());
+                    continue;
+                }
+
                 // Compare versions (flag if declared <= parent)
                 try {
-                    ComparableVersion declared = new ComparableVersion(declaredValue);
+                    ComparableVersion declared = new ComparableVersion(resolvedDeclaredValue);
                     ComparableVersion parent = new ComparableVersion(parentValue);
 
                     if (declared.compareTo(parent) <= 0) {
-                        propertyViolations.add(new ObsoletePropertyOverride(propName, declaredValue, parentValue));
+                        propertyViolations.add(
+                                new ObsoletePropertyOverride(propName, resolvedDeclaredValue, parentValue));
                     }
                 } catch (Exception e) {
                     getLog().debug("[RequireNonObsoleteDependencyManagement] Failed to compare property versions for "
-                            + propName + ": declared=" + declaredValue + ", parent=" + parentValue + ": "
+                            + propName + ": declared=" + resolvedDeclaredValue + ", parent=" + parentValue + ": "
                             + e.getMessage());
                 }
             }

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -122,12 +122,16 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                 Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
                 for (Dependency bomDep : importedBoms) {
                     try {
+                        String resolvedGroupId =
+                                bomResolverUtil.resolveProperties(getLog(), bomDep.getGroupId(), project);
+                        String resolvedArtifactId =
+                                bomResolverUtil.resolveProperties(getLog(), bomDep.getArtifactId(), project);
                         String resolvedVersion =
                                 bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
                         Map<String, BomResolverUtil.BomManagedDependency> resolved =
                                 bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
-                        getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId()
-                                + ":" + bomDep.getArtifactId() + ":" + resolvedVersion + " with " + resolved.size()
+                        getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + resolvedGroupId + ":"
+                                + resolvedArtifactId + ":" + resolvedVersion + " with " + resolved.size()
                                 + " managed dependencies");
                         // Later BOMs override earlier ones
                         bomDependencies.putAll(resolved);

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -97,7 +97,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
     @Override
     public void execute() throws EnforcerRuleException {
         if (skip) {
-            getLog().info("[RequireNonObsoleteDependencyManagement] Skipping rule");
+            getLog().info("requireNonObsoleteDependencyManagement skipped");
             return;
         }
 
@@ -115,7 +115,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             }
 
             if (!importedBoms.isEmpty()) {
-                getLog().info("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size()
+                getLog().debug("[RequireNonObsoleteDependencyManagement] Found " + importedBoms.size()
                         + " imported BOM(s)");
 
                 // Phase 2: Resolve BOM managed dependencies
@@ -130,7 +130,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
                                 bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
                         Map<String, BomResolverUtil.BomManagedDependency> resolved =
                                 bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
-                        getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + resolvedGroupId + ":"
+                        getLog().debug("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + resolvedGroupId + ":"
                                 + resolvedArtifactId + ":" + resolvedVersion + " with " + resolved.size()
                                 + " managed dependencies");
                         // Later BOMs override earlier ones
@@ -322,7 +322,7 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
             throw new EnforcerRuleException(message.toString());
         }
 
-        getLog().info("[RequireNonObsoleteDependencyManagement] No obsolete overrides found");
+        getLog().debug("[RequireNonObsoleteDependencyManagement] No obsolete overrides found");
     }
 
     private record ObsoleteOverride(

--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/enforcer/RequireNonObsoleteDependencyManagement.java
@@ -127,10 +127,11 @@ public class RequireNonObsoleteDependencyManagement extends AbstractEnforcerRule
         Map<String, BomResolverUtil.BomManagedDependency> bomDependencies = new LinkedHashMap<>();
         for (Dependency bomDep : importedBoms) {
             try {
+                String resolvedVersion = bomResolverUtil.resolveProperties(getLog(), bomDep.getVersion(), project);
                 Map<String, BomResolverUtil.BomManagedDependency> resolved =
                         bomResolverUtil.resolveBomManagedDependencies(getLog(), bomDep, project);
                 getLog().info("[RequireNonObsoleteDependencyManagement] Resolved BOM: " + bomDep.getGroupId() + ":"
-                        + bomDep.getArtifactId() + ":" + bomDep.getVersion() + " with " + resolved.size()
+                        + bomDep.getArtifactId() + ":" + resolvedVersion + " with " + resolved.size()
                         + " managed dependencies");
                 // Later BOMs override earlier ones
                 bomDependencies.putAll(resolved);


### PR DESCRIPTION
Intended to ease the burden of maintaining plugin POMs with temporary `dependencyManagement` overrides that are obsoleted by `bom-*` updates further down the road.

[Custom rule docs](https://maven.apache.org/enforcer/enforcer-api/writing-a-custom-rule.html)

Some possible enhancements:
- [x] check for obsolete version properties (like `jenkins.version` inherited from a CloudBees CI intermediate parent)
- [ ] check for obsolete `<version>` overrides in `<dependency>`s not in `<dependencyManagement>` (though people should really be using `<dependencyManagement>`)
- [x] fails to resolve non-`parent` aggregator when used as imported BOM `<version>${project.version}</version>` (occurs in CloudBees CI `cloudbees-replication` though does not matter in that case); `resolveProperties` probably using the wrong API
- [x] error in `cloudbees-casc` :`declared ${project.version} < …`

A little rough but seems to work well enough to be useful now.

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-64716)